### PR TITLE
ci/AzurePipelines: Remove checkout step in PatchCheck YML

### DIFF
--- a/ci/AzurePipelines/Ubuntu-PatchCheck.yml
+++ b/ci/AzurePipelines/Ubuntu-PatchCheck.yml
@@ -21,9 +21,6 @@ pool:
   vmImage: 'ubuntu-latest'
 
 steps:
-- checkout: self
-  clean: true
-
 - task: UsePythonVersion@0
   inputs:
     versionSpec: '3.7.x'


### PR DESCRIPTION
The default Azure Pipelines checkout behavior should
work for PatchCheck.  Remove redundant checkout step.

Signed-off-by: Kinney <michael.d.kinney@intel.com>