### PR TITLE
.mergify/config.yml: Fix author not in @tianocore/edk-ii-maintainers

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -58,7 +58,7 @@ pull_request_rules:
     conditions:
       - base=edk2-ci
       - label=push
-      - author!=@tianocore/edk-ii-maintainers
+      - -author=@tianocore/edk-ii-maintainers
     actions:
       close:
         message: PR submitter is not a member of the Tianocore EDK II Maintainers team


### PR DESCRIPTION
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>