### PR TITLE
.azurepipelines: Don't copy BaseTools build log of 0 packages

### DIFF
--- a/.azurepipelines/templates/basetools-build-steps.yml
+++ b/.azurepipelines/templates/basetools-build-steps.yml
@@ -33,4 +33,4 @@ steps:
     contents: |
       BASETOOLS_BUILD*.*
     flattenFolders: true
-  condition: succeededOrFailed()
+  condition: and(gt(variables.pkg_count, 0), succeededOrFailed())


### PR DESCRIPTION
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>