### PR TITLE
MdeModulePkg: Remove SerialDxe duplicate GUID exception

### DIFF
--- a/MdeModulePkg/MdeModulePkg.ci.yaml
+++ b/MdeModulePkg/MdeModulePkg.ci.yaml
@@ -45,7 +45,6 @@
             "gEdkiiFormBrowserExProtocolGuid=gEfiFormBrowserExProtocolGuid",
             "gEfiPeiMmAccessPpiGuid=gPeiSmmAccessPpiGuid",
             "gPeiSmmControlPpiGuid=gEfiPeiMmControlPpiGuid",
-            "gEdkiiSerialPortLibVendorGuid=SerialDxe"  # Is this a bug????
         ]
     },
 


### PR DESCRIPTION
Remove the following IgnoreDuplicates line in GuidCheck
CI test.

  "gEdkiiSerialPortLibVendorGuid=SerialDxe"

This duplicate GUID was resolved by the following commits:

SHA-1: 0d85e67714e31e0dbe4241ab2ebb7c423aba174d
* MdeModulePkg/SerialDxe: Update the file Guid in SerialDxe.inf

SHA-1: 9790f62be1aa5ee9460d4c4ec8c720919523bb62
* MdeModulePkg SerialDxe.inf: Fix wrong FILE_GUID format

Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>