### PR TITLE
Readme.md: Use HTML instead of markdown for status badges

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,10 +5,50 @@ for the UEFI and PI specifications from www.uefi.org.
 
 # Build Status
 
-| Host Type | Toolchain | Branch  | Build Status | Test Status | Code Coverage |
-| :-------- | :-------- | :------ | :----------- | :---------- | :------------ |
-| Windows   | VS2019    | edk2-ci | [![Build Status](https://dev.azure.com/tianocore/edk2-ci-play/_apis/build/status/edk2-staging/Windows%20VS2019%20CI?branchName=edk2-ci)](https://dev.azure.com/tianocore/edk2-ci-play/_build/latest?definitionId=27&branchName=edk2-ci) | [![Azure DevOps tests](https://img.shields.io/azure-devops/tests/tianocore/edk2-ci-play/14.svg)](https://dev.azure.com/tianocore/edk2-ci-play/_build/latest?definitionId=27&branchName=edk2-ci) | [![Code Coverage](https://img.shields.io/badge/coverage-coming_soon-blue)](https://dev.azure.com/tianocore/edk2-ci-play/_build/latest?definitionId=27&branchName=edk2-ci) |
-| Ubuntu    | GCC       | edk2-ci | [![Build Status](https://dev.azure.com/tianocore/edk2-ci-play/_apis/build/status/edk2-staging/Ubuntu%20GCC5%20CI?branchName=edk2-ci)](https://dev.azure.com/tianocore/edk2-ci-play/_build/latest?definitionId=26&branchName=edk2-ci)    | [![Azure DevOps tests](https://img.shields.io/azure-devops/tests/tianocore/edk2-ci-play/15.svg)](https://dev.azure.com/tianocore/edk2-ci-play/_build/latest?definitionId=26&branchName=edk2-ci) | [![Code Coverage](https://img.shields.io/badge/coverage-coming_soon-blue)](https://dev.azure.com/tianocore/edk2-ci-play/_build/latest?definitionId=26&branchName=edk2-ci) |
+<table>
+  <tr>
+    <th>Host Type</th>
+    <th>Toolchain</th>
+    <th>Branch</th>
+    <th>Build Status</th>
+    <th>Test Status</th>
+    <th>Code Coverage</th>
+  </tr>
+  <tr>
+    <td>Windows</td>
+    <td>VS2019</td>
+    <td>edk2-ci</td>
+    <td>
+      <a  href="https://dev.azure.com/tianocore/edk2-ci-play/_build/latest?definitionId=27&branchName=edk2-ci">
+      <img src="https://dev.azure.com/tianocore/edk2-ci-play/_apis/build/status/edk2-staging/Windows%20VS2019%20CI?branchName=edk2-ci"/></a>
+    </td>
+    <td>
+      <a  href="https://dev.azure.com/tianocore/edk2-ci-play/_build/latest?definitionId=27&branchName=edk2-ci">
+      <img src="https://img.shields.io/azure-devops/tests/tianocore/edk2-ci-play/27.svg"/></a>
+    </td>
+    <td>
+      <a  href="https://dev.azure.com/tianocore/edk2-ci-play/_build/latest?definitionId=27&branchName=edk2-ci">
+      <img src="https://img.shields.io/badge/coverage-coming_soon-blue"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td>Ubuntu</td>
+    <td>GCC</td>
+    <td>edk2-ci</td>
+    <td>
+      <a  href="https://dev.azure.com/tianocore/edk2-ci-play/_build/latest?definitionId=26&branchName=edk2-ci">
+      <img src="https://dev.azure.com/tianocore/edk2-ci-play/_apis/build/status/edk2-staging/Ubuntu%20GCC5%20CI?branchName=edk2-ci"/></a>
+    </td>
+    <td>
+      <a  href="https://dev.azure.com/tianocore/edk2-ci-play/_build/latest?definitionId=26&branchName=edk2-ci">
+      <img src="https://img.shields.io/azure-devops/tests/tianocore/edk2-ci-play/26.svg"/></a>
+    </td>
+    <td>
+      <a  href="https://dev.azure.com/tianocore/edk2-ci-play/_build/latest?definitionId=26&branchName=edk2-ci">
+      <img src="https://img.shields.io/badge/coverage-coming_soon-blue"/></a>
+    </td>
+  </tr>
+</table>
 
 [More CI Build information](.pytool/Readme.md)
 


### PR DESCRIPTION
Use embedded HTML for the Build Status table to make the source
contents easier to read and maintain.

Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>