### PR TITLE
CryptoPkg/CryptoPkg.ci.yaml: Remove commented out line

### DIFF
--- a/CryptoPkg/CryptoPkg.ci.yaml
+++ b/CryptoPkg/CryptoPkg.ci.yaml
@@ -16,7 +16,6 @@
             "MdePkg/MdePkg.dec",
             "MdeModulePkg/MdeModulePkg.dec",
             "CryptoPkg/CryptoPkg.dec",
-            #"SecurityPkg/SecurityPkg.dec"
         ],
         # For host based unit tests
         "AcceptableDependencies-HOST_APPLICATION":[],


### PR DESCRIPTION
Remove commented out SecurityPkg from AcceptableDependencies
of the DependencyCheck.

Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>