### PR TITLE
Remove VirtioRng in Tdvf

### DIFF
--- a/TdvfPkg/TdvfPkg.dsc
+++ b/TdvfPkg/TdvfPkg.dsc
@@ -533,7 +533,6 @@
   OvmfPkg/Virtio10Dxe/Virtio10.inf
   OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
   OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
-  OvmfPkg/VirtioRngDxe/VirtioRng.inf
   MdeModulePkg/Universal/WatchdogTimerDxe/WatchdogTimer.inf
   MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounterRuntimeDxe.inf
   MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf

--- a/TdvfPkg/TdvfQemuFvMain.fdf.inc
+++ b/TdvfPkg/TdvfQemuFvMain.fdf.inc
@@ -54,7 +54,6 @@ INF  OvmfPkg/VirtioPciDeviceDxe/VirtioPciDeviceDxe.inf
 INF  OvmfPkg/Virtio10Dxe/Virtio10.inf
 INF  OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
 INF  OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
-INF  OvmfPkg/VirtioRngDxe/VirtioRng.inf
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
   INF  SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf


### PR DESCRIPTION
Support for virio-rng is not required because the VMM is not
trusted.  TD must use the RDSEED or RDRAND instruction to obtain
a random number.