### PR TITLE
tdvf: fix debug message in ProcessHobList()

### DIFF
--- a/TdvfPkg/TdShim/Sec/Hob.c
+++ b/TdvfPkg/TdShim/Sec/Hob.c
@@ -100,7 +100,7 @@ ProcessHobList (
 
         DEBUG((DEBUG_INFO, "ResourceAttribute: 0x%x\n", Hob.ResourceDescriptor->ResourceAttribute));
         DEBUG((DEBUG_INFO, "PhysicalStart: 0x%llx\n", Hob.ResourceDescriptor->PhysicalStart));
-        DEBUG((DEBUG_INFO, "ResourceLength: 0x%x\n", Hob.ResourceDescriptor->ResourceLength));
+        DEBUG((DEBUG_INFO, "ResourceLength: 0x%llx\n", Hob.ResourceDescriptor->ResourceLength));
         DEBUG((DEBUG_INFO, "Owner: %g\n\n", &Hob.ResourceDescriptor->Owner));
 
         PhysicalEnd = Hob.ResourceDescriptor->PhysicalStart + Hob.ResourceDescriptor->ResourceLength;


### PR DESCRIPTION
EFI_HOB_RESOURCE_DESCRIPTOR.ResourceLength is UINT64 which
requires %llx, not %x.

Signed-off-by: Isaku Yamahata <isaku.yamahata@intel.com>