### PR TITLE
Fix TDVF hangs after "Init Local APIC Timer Driver"

### DIFF
--- a/TdvfPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.c
+++ b/TdvfPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.c
@@ -632,11 +632,6 @@ InitializeApicTimer (
   //
   InitializeLocalApicSoftwareEnable (TRUE);
 
-  //
-  // Program init-count register.
-  //
-  WriteLocalApicReg (XAPIC_TIMER_INIT_COUNT_OFFSET, InitCount);
-
   if (DivideValue != 0) {
     ASSERT (DivideValue <= 128);
     ASSERT (DivideValue == GetPowerOfTwo32((UINT32)DivideValue));
@@ -660,6 +655,12 @@ InitializeApicTimer (
   LvtTimer.Bits.Mask = 0;
   LvtTimer.Bits.Vector = Vector;
   WriteLocalApicReg (XAPIC_LVT_TIMER_OFFSET, LvtTimer.Uint32);
+
+  //
+  // Program init-count register.
+  // It needs to be the last step to start the timer.
+  //
+  WriteLocalApicReg (XAPIC_TIMER_INIT_COUNT_OFFSET, InitCount);
 }
 
 /**

--- a/TdvfPkg/Override/UefiCpuPkg/LocalApicTimerDxe/LocalApicTimer.c
+++ b/TdvfPkg/Override/UefiCpuPkg/LocalApicTimerDxe/LocalApicTimer.c
@@ -431,11 +431,6 @@ TimerDriverInitialize (
   //
   Status = gBS->LocateProtocol (&gEfiCpuArchProtocolGuid, NULL, (VOID **) &mCpu);
   ASSERT_EFI_ERROR (Status);
-  //
-  // Force the Local APIC timer to be disabled while setting everything up
-  //
-  DisableApicTimerInterrupt ();
-  InitializeApicTimer (0, 0, FALSE, PcdGet8 (PcdHpetLocalApicVector));
 
   //
   // Install interrupt handler for the Local APIC Timer
@@ -446,6 +441,12 @@ TimerDriverInitialize (
     DEBUG ((DEBUG_ERROR, "Unable to register Local APIC interrupt with CPU Arch Protocol.  Unload Local APIC timer driver.\n"));
     return EFI_DEVICE_ERROR;
   }
+
+  //
+  // Force the Local APIC timer to be disabled while setting everything up
+  //
+  DisableApicTimerInterrupt ();
+  InitializeApicTimer (0, 0, FALSE, PcdGet8 (PcdHpetLocalApicVector));
 
   //
   // Force the Local APIC Timer to be enabled at its default period


### PR DESCRIPTION
Patch 1 is to fix the case that InitializeApicTimer() enables TimerInterrupt before timer interrupt handler registered in TDVF.

>     DisableApicTimerInterrupt ();
>     InitializeApicTimer (0, 0, FALSE, PcdGet8 (PcdHpetLocalApicVector));
>   
>     //
>     // Install interrupt handler for the Local APIC Timer
>     //
>     Status = mCpu->RegisterInterruptHandler (mCpu, PcdGet8 (PcdHpetLocalApicVector), TimerInterruptHandler);

If there is a timer interrupt pending before InitializeApicTimer(), then the timer interrupt will be delivered after InitializeApicTimer() but before mCpu->RegisterInterruptHandler(). Since no timer interrupt handler, there is no eoi to clear timer interrupt in ISR, then the following timer interrupt cannot be delivered.

An alternative is to register the handler before InitializeApicTimer().


Patch 2 is to fix the issue TDVF hangs in the below loop due to not get enough timer interrupt.

  

> DEBUG_CODE (
>     //
>     // Wait for a few timer interrupts to fire before continuing
>     // 
>     while (mNumTicks < 10);
>   );

The root-cause is in the flow:

TimerDriverInitialize()
  -> TimerDriverSetTimerPeriod (&mTimer, PcdGet64 (PcdHpetDefaultTimerPeriod))
     -> InitializeApicTimer (0, (UINT32)TimerCount, TRUE, PcdGet8 (PcdHpetLocalApicVector))

In InitializeApicTimer(), it sets TIMER_INIT_COUNT before set the mode
to periodic. If the TD guest runs slowly, it's possible that timer expires
before mode changed to periodic. Thus it doesn't restart timer.