### PR TITLE
Fix issue ValidateHobList() will hang when the Hob.Header.Hoblength equal 0

### DIFF
--- a/TdvfPkg/TdShim/Sec/Hob.c
+++ b/TdvfPkg/TdShim/Sec/Hob.c
@@ -144,6 +144,11 @@ ValidateHobList (
       DEBUG((DEBUG_ERROR, "HOB: Hob header Reserved filed should be zero\n"));
       return FALSE; 
     }
+    
+    if (Hob.Header->HobLength == 0) {
+        DEBUG((DEBUG_ERROR, "HOB: Hob header LEANGTH should not be zero\n"));
+        return FALSE;
+    }
 
     switch (Hob.Header->HobType) {
       case EFI_HOB_TYPE_HANDOFF:


### PR DESCRIPTION
Fix issue ValidateHobList() will hang when the Hob.Header.Hoblength equals 0

Signed-off-by: Wei Liu <weix.c.liu@intel.com>