### PR TITLE
TDVF: fix the GPAW mask

### DIFF
--- a/TdvfPkg/TdShim/ResetVector/Ia32/Flat32ToFlat64.asm
+++ b/TdvfPkg/TdShim/ResetVector/Ia32/Flat32ToFlat64.asm
@@ -22,7 +22,7 @@ Transition32FlatTo64Flat:
     ; LA57 and use 5-level paging
     ;
     mov     ebx, esp
-    and     ebx, 0x2f
+    and     ebx, 0x3f
     cmp     ebx, 52
     jl      .set_cr4
     bts     eax, 12 


### PR DESCRIPTION
bit[5:0] of ESP stores the GPAW of TD guest, which can be 48 or 52, and
the mask of it should be 0x3f

Signed-off-by: Xiaoyao Li <xiaoyao.li@intel.com>