### PR TITLE
Fix Tcg2MeasureGptTable hang issue

### DIFF
--- a/TdvfPkg/UefiPayload/Library/DxeTpm2MeasureBootLibTdx/DxeTpm2MeasureBootLibTdx.c
+++ b/TdvfPkg/UefiPayload/Library/DxeTpm2MeasureBootLibTdx/DxeTpm2MeasureBootLibTdx.c
@@ -157,6 +157,14 @@ Tcg2MeasureGptTable (
   if (PrimaryHeader == NULL) {
     return EFI_OUT_OF_RESOURCES;
   }
+  //
+  // PrimaryHeader->SizeOfPartitionEntry should not be zero
+  // 
+  if (PrimaryHeader->SizeOfPartitionEntry == 0) {
+    DEBUG ((EFI_D_ERROR, "SizeOfPartitionEntry should not be zero!\n"));
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
   Status = DiskIo->ReadDisk (
                      DiskIo,
                      BlockIo->Media->MediaId,


### PR DESCRIPTION
Tcg2MeasureGptTable will hang when the PrimaryHeader->SizeOfPartitionEntry  equals 0

Signed-off-by: Wei Liu <weix.c.liu@intel.com>