### PR TITLE
TDVF: Ignore option rom for incompatible devices.

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
@@ -73,7 +73,6 @@
   BaseLib
   UefiDriverEntryPoint
   DebugLib
-  TdxProbeLib
 
 [Protocols]
   gEfiPciHotPlugRequestProtocolGuid               ## SOMETIMES_PRODUCES

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumerator.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumerator.c
@@ -535,9 +535,6 @@ GetMaxOptionRomSize (
   UINT32          TempOptionRomSize;
 
   MaxOptionRomSize = 0;
-  if(ProbeTdGuest()) {
-    return 0;
-  }
 
   //
   // Go through bridges to reach all devices

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.h
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.h
@@ -262,6 +262,7 @@ DetermineDeviceAttribute (
 
   @param PciIoDevice      Input Pci device instance. Output Pci device instance with updated
                           Bar information.
+  @param IgnoreOptionRom  Output If the option rom of incompatible device need to be ignored.
 
   @retval EFI_SUCCESS     Successfully updated bar information.
   @retval EFI_UNSUPPORTED Given PCI device doesn't belong to incompatible PCI device list.
@@ -269,7 +270,8 @@ DetermineDeviceAttribute (
 **/
 EFI_STATUS
 UpdatePciInfo (
-  IN OUT PCI_IO_DEVICE    *PciIoDevice
+  IN OUT PCI_IO_DEVICE    *PciIoDevice,
+     OUT BOOLEAN          *IgnoreOptionRom
   );
 
 /**

--- a/OvmfPkg/IncompatiblePciDeviceSupportDxe/IncompatiblePciDeviceSupport.c
+++ b/OvmfPkg/IncompatiblePciDeviceSupportDxe/IncompatiblePciDeviceSupport.c
@@ -45,16 +45,11 @@ STATIC EFI_INCOMPATIBLE_PCI_DEVICE_SUPPORT_PROTOCOL
 typedef struct {
   EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR AddressSpaceDesc;
   EFI_ACPI_END_TAG_DESCRIPTOR       EndDesc;
-} MMIO64_PREFERENCE;
-
-typedef struct {
-  EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR AddressSpaceDesc;
-  EFI_ACPI_END_TAG_DESCRIPTOR       EndDesc;
-} OPTION_ROM_PREFERENCE;
+} ADDRESS_DESCRIPTOR_CONFIGURATION;
 
 #pragma pack ()
 
-STATIC CONST MMIO64_PREFERENCE mMmio6Configuration = {
+STATIC CONST ADDRESS_DESCRIPTOR_CONFIGURATION mMmio6Configuration = {
   //
   // AddressSpaceDesc
   //
@@ -92,7 +87,7 @@ STATIC CONST MMIO64_PREFERENCE mMmio6Configuration = {
   }
 };
 
-STATIC CONST OPTION_ROM_PREFERENCE mOptionRomConfiguration = {
+STATIC CONST ADDRESS_DESCRIPTOR_CONFIGURATION mOptionRomConfiguration = {
   //
   // AddressSpaceDesc
   //
@@ -107,7 +102,7 @@ STATIC CONST OPTION_ROM_PREFERENCE mOptionRomConfiguration = {
       ),
     ACPI_ADDRESS_SPACE_TYPE_MEM,                   // ResType
     0,                                             // GenFlag
-    BIT0,                                          // Disable option roms SpecificFlag
+    0,                                             // Disable option roms SpecificFlag
     64,                                            // AddrSpaceGranularity:
                                                    //   aperture selection hint
                                                    //   for BAR allocation
@@ -115,7 +110,7 @@ STATIC CONST OPTION_ROM_PREFERENCE mOptionRomConfiguration = {
     MAX_UINT64,                                    // AddrRangeMax:
                                                    //   no special alignment
                                                    //   for affected BARs
-    MAX_UINT64,                                    // AddrTranslationOffset:
+    6,                                             // AddrTranslationOffset:
                                                    //   hint covers all
                                                    //   eligible BARs
     0                                              // AddrLen:
@@ -295,7 +290,7 @@ AllocateConfiguration:
     if(TdGuest) {
     DEBUG ((DEBUG_WARN,
       "%a: Check device for Option ROM of PCI 0x%04x:0x%04x (rev %d) failed.\n\n",
-      __FUNCTION__, (UINT32)VendorId, (UINT32)DeviceId, (UINT8)RevisionId));      
+      __FUNCTION__, (UINT32)VendorId, (UINT32)DeviceId, (UINT8)RevisionId));
     } else {
       DEBUG ((DEBUG_WARN,
         "%a: 64-bit MMIO BARs may be degraded for PCI 0x%04x:0x%04x (rev %d)\n",


### PR DESCRIPTION
VMM can inject option ROM which is untrusted in TDX, so PCI option ROM
needs to be ignored. According to "Table 20. ACPI 2.0 & 3.0 QWORD Address
Space Descriptor Usage" PI spec 1.7, type-specific flags can be set to 0
when Address Translation Offset == 6 to skip device option ROM.

This commit changes the option rom configuration in TDX and modifies the
PciSearchDevice() method to judge the condition described in PI spec.