### PR TITLE
TDVF: Correct the PCR index used by BootVariable measurement

### DIFF
--- a/OvmfPkg/Tcg/Tcg2Dxe/TdTcg2Dxe.c
+++ b/OvmfPkg/Tcg/Tcg2Dxe/TdTcg2Dxe.c
@@ -1955,8 +1955,12 @@ ReadAndMeasureBootVariable (
   OUT     VOID                      **VarData
   )
 {
+  //
+  // Boot variables are measured into (PCR[5]) RTMR[1],
+  // details in section 8.1 of TDVF design guide.
+  //
   return ReadAndMeasureVariable (
-           1,
+           5,
            EV_EFI_VARIABLE_BOOT,
            VarName,
            VendorGuid,


### PR DESCRIPTION
According to section 8.1 of TDVF design guid, BootVariable should be
measured into RTMR[1] (PCR[5]).