### PR TITLE
OvmfPkg: Add FV length check in ValidateTdxCfv()

### DIFF
--- a/OvmfPkg/EmuVariableFvbRuntimeDxe/Fvb.c
+++ b/OvmfPkg/EmuVariableFvbRuntimeDxe/Fvb.c
@@ -671,7 +671,8 @@ ValidateTdxCfv (
       (CfvFvHeader->Signature != EFI_FVH_SIGNATURE) ||
       (CfvFvHeader->Attributes != 0x4feff) ||
       (CfvFvHeader->HeaderLength != EMU_FV_HEADER_LENGTH) ||
-      (CfvFvHeader->Revision != EFI_FVH_REVISION)
+      (CfvFvHeader->Revision != EFI_FVH_REVISION) ||
+	  (CfvFvHeader->FvLength != TdxCfvSize)
       ) {
     DEBUG ((DEBUG_ERROR, "TDX CFV: Basic FV headers were invalid\n"));
     return FALSE;

--- a/OvmfPkg/OvmfPkgDefines.fdf.inc
+++ b/OvmfPkg/OvmfPkgDefines.fdf.inc
@@ -85,7 +85,7 @@ SET gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize = $(VARS_SPARE_
 
 SET gUefiOvmfPkgTokenSpaceGuid.PcdCfvBase           = $(FW_BASE_ADDRESS)
 SET gUefiOvmfPkgTokenSpaceGuid.PcdCfvRawDataOffset  = $(VARS_OFFSET)
-SET gUefiOvmfPkgTokenSpaceGuid.PcdCfvRawDataSize    = $(VARS_LIVE_SIZE)
+SET gUefiOvmfPkgTokenSpaceGuid.PcdCfvRawDataSize    = $(VARS_SIZE)
 
 SET gUefiOvmfPkgTokenSpaceGuid.PcdBfvBase           = $(CODE_BASE_ADDRESS)
 SET gUefiOvmfPkgTokenSpaceGuid.PcdBfvRawDataOffset  = $(VARS_SIZE)


### PR DESCRIPTION
1. Fix crash issue found via fuzzing test, current code lack of check between CfvFvHeader->FvLength and TdxCfvSize in ValidateTdxfCfv().
2. Include FTW in TDVF implementation CFV.

Signed-off-by: Wei Liu <wei3.liu@intel.com>