### PR TITLE
OvmfPkg: set DXE memory protection policy

### DIFF
--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -632,7 +632,7 @@
   # Noexec settings for DXE.
   # TDX doesn't allow us to change EFER so make sure these are disabled
   #gEfiMdeModulePkgTokenSpaceGuid.PcdImageProtectionPolicy|0x00000000
-  gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy|0x00000000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy|0x7FD5
   # Noexec settings for DXE.
   # TDX doesn't allow us to change EFER so make sure these are disabled
   #gEfiMdeModulePkgTokenSpaceGuid.PcdSetNxForStack|FALSE


### PR DESCRIPTION
Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>