### PR TITLE
MicroPythonDxe: Fixed an issue where struct arrays can always access only the attributes of the first element.

### DIFF
--- a/MicroPythonPkg/MicroPythonDxe/Uefi/objuefi.c
+++ b/MicroPythonPkg/MicroPythonDxe/Uefi/objuefi.c
@@ -800,12 +800,12 @@ STATIC mp_obj_t get_value(mp_obj_mem_t *self, mp_obj_t index_in)
       break;
 
     case 'O':
-      value = efi_mem_new_n((UINT8 *)addr + index * self->typesize, 1, NULL, self->readonly, self->page);
+      value = efi_mem_new_n((UINT8 *)addr + index * self->typesize, 1, self->typespec, self->readonly, self->page);
       memobj = MP_OBJ_TO_PTR(value);
-      memobj->typespec = self->typespec;
-      memobj->typesize = self->typesize;
-      memobj->size = self->typesize;
-      memobj->fields = self->fields;
+      // memobj->typespec = self->typespec;
+      // memobj->typesize = self->typesize;
+      // memobj->size = self->typesize;
+      // memobj->fields = self->fields;
       memobj->typeattr = self->typeattr;
       break;
 


### PR DESCRIPTION
To get the value of a typespec OrderedDict mem object and
create a pointer to the mem object corresponding to index,
we should pass `typespec` into the function `efi_mem_new_n` and
let the `efi_mem_typecast` function map the entire fields of OrderedDict object,
rather than simply assigning fields after creating the mem object
![issue_20211218010904](https://user-images.githubusercontent.com/18024989/146582511-a43a6762-91b3-4052-bf5d-4e172ecc04f3.jpg)
![fixed_issue_20211218011308](https://user-images.githubusercontent.com/18024989/146582546-73ba724d-9119-466f-bfe5-7a1bb33a3645.jpg)
.