### PR TITLE
OvmfPkg: VirtioBlk check device configurations from PCI capabilities

### DIFF
--- a/OvmfPkg/Include/Library/TdvfPlatformLib.h
+++ b/OvmfPkg/Include/Library/TdvfPlatformLib.h
@@ -18,6 +18,7 @@ typedef struct {
   UINT16                  HostBridgePciDevId;
   BOOLEAN                 SetNxForStack;
   UINT8                   SystemStates[6];
+  UINT64                  SystemMemoryEnd;
 } EFI_HOB_PLATFORM_INFO;
 #pragma pack()
 VOID

--- a/OvmfPkg/Library/TdxStartupLib/Hob.c
+++ b/OvmfPkg/Library/TdxStartupLib/Hob.c
@@ -322,6 +322,39 @@ ValidateHobList (
   return TRUE;
 }
 
+EFI_PHYSICAL_ADDRESS
+EFIAPI
+GetSystemMemoryEndAddress (
+  IN CONST VOID            *VmmHobList
+  )
+{
+  EFI_PEI_HOB_POINTERS        Hob;
+  EFI_PHYSICAL_ADDRESS        PhysicalEnd;
+
+  ASSERT (VmmHobList != NULL);
+
+  Hob.Raw = (UINT8 *) VmmHobList;
+  PhysicalEnd = 0;
+
+  //
+  // Parse the HOB list until end of list or matching type is found.
+  //
+  while (!END_OF_HOB_LIST (Hob)) {
+    switch (Hob.Header->HobType) {
+      case EFI_HOB_TYPE_RESOURCE_DESCRIPTOR:
+        if (Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) {
+          if (PhysicalEnd < Hob.ResourceDescriptor->PhysicalStart + Hob.ResourceDescriptor->ResourceLength) {
+            PhysicalEnd = Hob.ResourceDescriptor->PhysicalStart + Hob.ResourceDescriptor->ResourceLength;
+          }
+        }
+    }
+    Hob.Raw = GET_NEXT_HOB (Hob);
+  }
+
+  DEBUG ((DEBUG_INFO, "System memory end address = 0x%llx\n", PhysicalEnd));
+  return PhysicalEnd;
+}
+
 /**
   Processing the incoming HobList for the TD
 

--- a/OvmfPkg/Library/TdxStartupLib/TdxStartup.c
+++ b/OvmfPkg/Library/TdxStartupLib/TdxStartup.c
@@ -112,6 +112,8 @@ TdxStartup(
     CpuDeadLoop ();
   }
 
+  PlatformInfoHob.SystemMemoryEnd = GetSystemMemoryEndAddress (VmmHobList);
+
   //
   // Process Hoblist for the TD
   //

--- a/OvmfPkg/Library/TdxStartupLib/TdxStartupInternal.h
+++ b/OvmfPkg/Library/TdxStartupLib/TdxStartupInternal.h
@@ -66,6 +66,12 @@ ProcessHobList (
   IN CONST VOID             *HobStart
   );
 
+EFI_PHYSICAL_ADDRESS
+EFIAPI
+GetSystemMemoryEndAddress (
+  IN CONST VOID             *HobStart
+  );
+
 VOID
 EFIAPI
 TransferHobList (

--- a/OvmfPkg/OvmfPkg.dec
+++ b/OvmfPkg/OvmfPkg.dec
@@ -387,6 +387,9 @@
   ## This PCD records LASA field in TDX EVENTLOG ACPI table.
   gUefiOvmfPkgTokenSpaceGuid.PcdTdxEventlogAcpiTableLasa|0|UINT64|0x104
 
+  ## This PCD records the system memory end address in Tdx guest
+  gUefiOvmfPkgTokenSpaceGuid.PcdTdxSystemMemoryEnd|0|UINT64|0x105
+
 [PcdsFeatureFlag]
   gUefiOvmfPkgTokenSpaceGuid.PcdQemuBootOrderPciTranslation|TRUE|BOOLEAN|0x1c
   gUefiOvmfPkgTokenSpaceGuid.PcdQemuBootOrderMmioTranslation|FALSE|BOOLEAN|0x1d

--- a/OvmfPkg/TdxDxe/TdxDxe.c
+++ b/OvmfPkg/TdxDxe/TdxDxe.c
@@ -214,6 +214,9 @@ TdxDxeEntryPoint (
   if (PlatformInfo) {
     PcdSet16S (PcdOvmfHostBridgePciDevId, PlatformInfo->HostBridgePciDevId);
 
+    ASSERT (PlatformInfo->SystemMemoryEnd != 0);
+    PcdSet64S (PcdTdxSystemMemoryEnd, PlatformInfo->SystemMemoryEnd);
+
     if ((Res = GetResourceDescriptor(EFI_RESOURCE_MEMORY_MAPPED_IO, (EFI_PHYSICAL_ADDRESS)0x100000000, (EFI_PHYSICAL_ADDRESS)-1)) != NULL) {
       INIT_PCDSET(PcdPciMmio64, Res);
     }

--- a/OvmfPkg/TdxDxe/TdxDxe.inf
+++ b/OvmfPkg/TdxDxe/TdxDxe.inf
@@ -62,4 +62,5 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdTdRelocatedMailboxBase
   gUefiCpuPkgTokenSpaceGuid.PcdCpuLocalApicBaseAddress
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFdBaseAddress
+  gUefiOvmfPkgTokenSpaceGuid.PcdTdxSystemMemoryEnd
 

--- a/OvmfPkg/Virtio10Dxe/Virtio10.inf
+++ b/OvmfPkg/Virtio10Dxe/Virtio10.inf
@@ -31,6 +31,10 @@
   UefiBootServicesTableLib
   UefiDriverEntryPoint
   UefiLib
+  PcdLib
+
+[Pcd]
+  gUefiOvmfPkgTokenSpaceGuid.PcdTdxSystemMemoryEnd
 
 [Protocols]
   gEfiPciIoProtocolGuid     ## TO_START


### PR DESCRIPTION
VirtioBlk(1.0) driver should check device configurations infomations
from PCI capabilities

Below checks need to do:
 - address + offset should not overflow.
 - address + offset + length should not overflow.
 - each [address, address + offset + length] should not overlap.
 - offset + length should be smaller than BAR size allocated by hardware.
 - offset + length should be smaller than the expected data structure
   size.
 - [address, address + offset + length] region does not overlap with
   DRAM size in TD.

Based upon above requirements, this patch contains below changes:
 - Add PcdTdxSystemMemoryEnd to record the DRAM size.
 - Calculate the DRAM size based on the resource descriptor hob in TdHob
   and record the value in PlatformInfoHob. Then in TdxDxe this value
   is set to PcdTdxSystemMemoryEnd.
 - VirtioBlk (1.0) is the interested driver so the checking is limited
   in virtio 1.0. This is because VirtiIoBlk is in the minimal driver
   list for Tdx guest.
 - In Virtio10Dxe these checks will be run to make sure VirtiIoBlk device
   configurations from PCI capabilities are legal.

Signed-off-by: Min Xu <min.m.xu@intel.com>