### PR TITLE
Bounds check bypass

### DIFF
--- a/OvmfPkg/AcpiPlatformDxe/Qemu.c
+++ b/OvmfPkg/AcpiPlatformDxe/Qemu.c
@@ -343,6 +343,7 @@ GetSuspendStates (
       DEBUG ((DEBUG_INFO, "ACPI using S3/S4 defaults\n"));
       return;
     }
+    SpeculationBarrier ();
     QemuFwCfgSelectItem (FwCfgItem);
     QemuFwCfgReadBytes (sizeof SystemStates, SystemStates);
   }

--- a/OvmfPkg/AcpiPlatformDxe/QemuFwCfgAcpi.c
+++ b/OvmfPkg/AcpiPlatformDxe/QemuFwCfgAcpi.c
@@ -695,6 +695,7 @@ ProcessCmdWritePointer (
     return EFI_PROTOCOL_ERROR;
   }
 
+  SpeculationBarrier ();
   PointeeBlob = OrderedCollectionUserStruct (PointeeEntry);
   PointerValue = WritePointer->PointeeOffset;
   if (PointerValue >= PointeeBlob->Size) {

--- a/OvmfPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
+++ b/OvmfPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
@@ -252,6 +252,7 @@ PciHostBridgeGetRootBridges (
   if (EFI_ERROR (Status) || FwCfgSize != sizeof ExtraRootBridges) {
     ExtraRootBridges = 0;
   } else {
+    SpeculationBarrier ();
     QemuFwCfgSelectItem (FwCfgItem);
     QemuFwCfgReadBytes (FwCfgSize, &ExtraRootBridges);
 

--- a/OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParser.c
+++ b/OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParser.c
@@ -106,6 +106,7 @@ QemuFwCfgGetAsString (
     return RETURN_PROTOCOL_ERROR;
   }
 
+  SpeculationBarrier ();
   QemuFwCfgSelectItem (FwCfgItem);
   QemuFwCfgReadBytes (FwCfgSize, Buffer);
 

--- a/OvmfPkg/Library/SmbiosVersionLib/DetectSmbiosVersionLib.c
+++ b/OvmfPkg/Library/SmbiosVersionLib/DetectSmbiosVersionLib.c
@@ -14,6 +14,7 @@
 #include <IndustryStandard/SmBios.h>
 
 #include <Base.h>
+#include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/PcdLib.h>
@@ -53,6 +54,7 @@ DetectSmbiosVersion (
     return RETURN_SUCCESS;
   }
 
+  SpeculationBarrier ();
   QemuFwCfgSelectItem (Anchor);
 
   switch (AnchorSize) {

--- a/OvmfPkg/Library/TdxStartupLib/TdxStartup.c
+++ b/OvmfPkg/Library/TdxStartupLib/TdxStartup.c
@@ -112,6 +112,8 @@ TdxStartup(
     CpuDeadLoop ();
   }
 
+  SpeculationBarrier ();
+
   PlatformInfoHob.SystemMemoryEnd = GetSystemMemoryEndAddress (VmmHobList);
 
   //


### PR DESCRIPTION
This is the reference link about Bounds Check Bypass
https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/advisory-guidance/bounds-check-bypass.html 

Software can insert a speculation stopping barrier between a bounds check and a later operation that coud cause a speculative side channel.