### PR TITLE
Add three new test configs:

### DIFF
--- a/DeviceSecurityPkg/Include/Test/TestConfig.h
+++ b/DeviceSecurityPkg/Include/Test/TestConfig.h
@@ -17,5 +17,8 @@
 #define TEST_CONFIG_MEAS_CAP_NO_SIG                         6
 #define TEST_CONFIG_NO_MEAS_CAP                             7
 #define TEST_CONFIG_NO_TRUST_ANCHOR                         8
+#define TEST_CONFIG_SECURITY_POLICY_AUTH_ONLY               9
+#define TEST_CONFIG_SECURITY_POLICY_MEAS_ONLY               10
+#define TEST_CONFIG_SECURITY_POLICY_NONE                    11
 
 #endif

--- a/DeviceSecurityPkg/Test/DeviceSecurityPolicyStub/DeviceSecurityPolicyStub.inf
+++ b/DeviceSecurityPkg/Test/DeviceSecurityPolicyStub/DeviceSecurityPolicyStub.inf
@@ -38,3 +38,6 @@
 
 [Depex]
   TRUE
+
+[Guids]
+  gEfiDeviceSecurityPkgTestConfig    ## CONSUMES


### PR DESCRIPTION
DeviceSecurityPolicy is Authentication Only,
DeviceSecurityPolicy is Measurement Only,
DeviceSecurityPolicy is None of Authentication and Measurement.

Signed-off-by: Zhao, Zhiqiang <zhiqiang.zhao@intel.com>