### PR TITLE
Add a new test config: the device reports that the measurement conten…

### DIFF
--- a/DeviceSecurityPkg/Include/Test/TestConfig.h
+++ b/DeviceSecurityPkg/Include/Test/TestConfig.h
@@ -20,5 +20,6 @@
 #define TEST_CONFIG_SECURITY_POLICY_AUTH_ONLY               9
 #define TEST_CONFIG_SECURITY_POLICY_MEAS_ONLY               10
 #define TEST_CONFIG_SECURITY_POLICY_NONE                    11
+#define TEST_CONFIG_MEASUREMENT_CONTENT_MODIFIED            12
 
 #endif

--- a/DeviceSecurityPkg/Test/SpdmDeviceSecretLibTestStub/SpdmDeviceSecretLibTestStub.c
+++ b/DeviceSecurityPkg/Test/SpdmDeviceSecretLibTestStub/SpdmDeviceSecretLibTestStub.c
@@ -274,6 +274,17 @@ RETURN_STATUS SpdmMeasurementCollectionFunc (
     UINTN total_size_needed;
     BOOLEAN use_bit_stream;
     UINTN measurement_block_size;
+    EFI_STATUS Status;
+    UINT8 TestConfig;
+    UINTN TestConfigSize;
+
+    Status = gRT->GetVariable (
+                L"SpdmTestConfig",
+                &gEfiDeviceSecurityPkgTestConfig,
+                NULL,
+                &TestConfigSize,
+                &TestConfig
+                );
 
     LIBSPDM_ASSERT(measurement_specification ==
                    SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF);
@@ -451,7 +462,11 @@ RETURN_STATUS SpdmMeasurementCollectionFunc (
         /* return content change*/
         if ((request_attribute & SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE) !=
             0) {
-            *content_changed = SPDM_MEASUREMENTS_RESPONSE_CONTENT_NO_CHANGE_DETECTED;
+            if (TestConfig == TEST_CONFIG_MEASUREMENT_CONTENT_MODIFIED) {
+                *content_changed = SPDM_MEASUREMENTS_RESPONSE_CONTENT_CHANGE_DETECTED;
+            } else {
+                *content_changed = SPDM_MEASUREMENTS_RESPONSE_CONTENT_NO_CHANGE_DETECTED;
+            }
         } else {
             *content_changed = SPDM_MEASUREMENTS_RESPONSE_CONTENT_CHANGE_NO_DETECTION;
         }


### PR DESCRIPTION
…t has been modified again.

Signed-off-by: Zhao, Zhiqiang <zhiqiang.zhao@intel.com>