### PR TITLE
Fix ValidateCryptHmac( ) function fail when running Cryptest.efi

### DIFF
--- a/DeviceSecurityPkg/Test/Cryptest/HmacVerify.c
+++ b/DeviceSecurityPkg/Test/Cryptest/HmacVerify.c
@@ -86,7 +86,7 @@ ValidateCryptHmac (
     return EFI_ABORTED;
   }
 
-  FreePool (HmacCtx);
+  HmacSha256Free (HmacCtx);
 
   Print (L"Check Value... ");
   if (CompareMem (Digest, HmacSha256Digest, SHA256_DIGEST_SIZE) != 0) {


### PR DESCRIPTION
Signed-off-by: Zhao, Zhiqiang <zhiqiang.zhao@intel.com>