### PR TITLE
Missing dependency import

### DIFF
--- a/HBFA/UefiHostFuzzTestCasePkg/TestCase/SecurityPkg/Library/DxeTpm2MeasureBootLib/TestTcg2MeasurePeImage.c
+++ b/HBFA/UefiHostFuzzTestCasePkg/TestCase/SecurityPkg/Library/DxeTpm2MeasureBootLib/TestTcg2MeasurePeImage.c
@@ -23,7 +23,7 @@
 #include <Library/Tcg2StubLib.h>
 #include <Library/PeCoffLib.h>
 #include <Library/DevicePathLib.h>
-
+#include <Protocol/CcMeasurement.h>
 
 
 #define TOTAL_SIZE   (512 * 1024)


### PR DESCRIPTION
Missing import of `CcMeasurement.h`, which defines the type `EFI_CC_MEASUREMENT_PROTOCOL`.