### PR TITLE
Add two test configs:

### DIFF
--- a/DeviceSecurityPkg/Include/Test/TestConfig.h
+++ b/DeviceSecurityPkg/Include/Test/TestConfig.h
@@ -26,5 +26,7 @@
 #define TEST_CONFIG_ECDSA_ECC_P256_SHA_256                  15
 #define TEST_CONFIG_ECDSA_ECC_P384_SHA_384                  16
 #define TEST_CONFIG_ECDSA_ECC_P521_SHA_512                  17
+#define TEST_CONFIG_SECP_256_R1_AES_256_GCM                 18
+#define TEST_CONFIG_SECP_521_R1_CHACHA20_POLY1305           19
 
 #endif

--- a/DeviceSecurityPkg/SpdmDeviceSecurityDxe/SpdmDeviceSecurityDxe.c
+++ b/DeviceSecurityPkg/SpdmDeviceSecurityDxe/SpdmDeviceSecurityDxe.c
@@ -433,9 +433,13 @@ CreateSpdmDriverContext (
            SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384 |
            SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512;
   SpdmSetData (SpdmContext, SpdmDataBaseHashAlgo, &Parameter, &Data32, sizeof(Data32));
-  Data16 = SPDM_ALGORITHMS_DHE_NAMED_GROUP_SECP_384_R1;
+  Data16 = SPDM_ALGORITHMS_DHE_NAMED_GROUP_SECP_256_R1 |
+           SPDM_ALGORITHMS_DHE_NAMED_GROUP_SECP_384_R1 |
+           SPDM_ALGORITHMS_DHE_NAMED_GROUP_SECP_521_R1;
   SpdmSetData (SpdmContext, SpdmDataDHENamedGroup, &Parameter, &Data16, sizeof(Data16));
-  Data16 = SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_128_GCM;
+  Data16 = SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_128_GCM |
+           SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_256_GCM |
+           SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_CHACHA20_POLY1305;
   SpdmSetData (SpdmContext, SpdmDataAEADCipherSuite, &Parameter, &Data16, sizeof(Data16));
   Data16 = SPDM_ALGORITHMS_KEY_SCHEDULE_HMAC_HASH;
   SpdmSetData (SpdmContext, SpdmDataKeySchedule, &Parameter, &Data16, sizeof(Data16));

--- a/DeviceSecurityPkg/Test/SpdmStub/SpdmStub.c
+++ b/DeviceSecurityPkg/Test/SpdmStub/SpdmStub.c
@@ -302,9 +302,21 @@ MainEntryPoint (
     Data32 = SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256;
   }
   SpdmSetData (SpdmContext, SpdmDataBaseHashAlgo, &Parameter, &Data32, sizeof(Data32));
-  Data16 = SPDM_ALGORITHMS_DHE_NAMED_GROUP_SECP_384_R1;
+  if (TestConfig == TEST_CONFIG_SECP_256_R1_AES_256_GCM) {
+    Data16 = SPDM_ALGORITHMS_DHE_NAMED_GROUP_SECP_256_R1;
+  } else if (TestConfig == TEST_CONFIG_SECP_521_R1_CHACHA20_POLY1305) {
+    Data16 = SPDM_ALGORITHMS_DHE_NAMED_GROUP_SECP_521_R1;
+  } else {
+    Data16 = SPDM_ALGORITHMS_DHE_NAMED_GROUP_SECP_384_R1;
+  }
   SpdmSetData (SpdmContext, SpdmDataDHENamedGroup, &Parameter, &Data16, sizeof(Data16));
-  Data16 = SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_128_GCM;
+  if (TestConfig == TEST_CONFIG_SECP_256_R1_AES_256_GCM) {
+    Data16 = SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_256_GCM;
+  } else if (TestConfig == TEST_CONFIG_SECP_521_R1_CHACHA20_POLY1305) {
+    Data16 = SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_CHACHA20_POLY1305;
+  } else {
+    Data16 = SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_128_GCM;
+  }
   SpdmSetData (SpdmContext, SpdmDataAEADCipherSuite, &Parameter, &Data16, sizeof(Data16));
   Data16 = SPDM_ALGORITHMS_KEY_SCHEDULE_HMAC_HASH;
   SpdmSetData (SpdmContext, SpdmDataKeySchedule, &Parameter, &Data16, sizeof(Data16));


### PR DESCRIPTION
Set SPDM responder support SECP_256_R1 and AES_256_GCM default.
Set SPDM responder support SECP_521_R1 and CHACHA20_POLY1305 default.

Signed-off-by: Zhao, Zhiqiang <zhiqiang.zhao@intel.com>