### PR TITLE
Fix EmulatorPkg build fail with GCC, variable ‘Status’ set but not used.

### DIFF
--- a/DeviceSecurityPkg/Test/Tcg2DumpLog/Tcg2DumpLog.c
+++ b/DeviceSecurityPkg/Test/Tcg2DumpLog/Tcg2DumpLog.c
@@ -233,6 +233,10 @@ DumpNvIndex (
               Offset,
               &OutData
               );
+  if (EFI_ERROR (Status)) {
+    Print (L"Tpm2NvRead - %r\n", Status);
+    return ;
+  }
 
   Print (L"PCR[0x%x] (Hash:0x%x): ", NvIndex, HashAlg);
   InternalDumpData (OutData.buffer, DataSize);


### PR DESCRIPTION
Signed-off-by: Zhao, Zhiqiang <zhiqiang.zhao@intel.com>