### PR TITLE
DeviceSecurityPkg: Add test different certificate chains.

### DIFF
--- a/DeviceSecurityPkg/Include/Test/TestConfig.h
+++ b/DeviceSecurityPkg/Include/Test/TestConfig.h
@@ -30,5 +30,6 @@
 #define TEST_CONFIG_SECP_521_R1_CHACHA20_POLY1305     19
 #define TEST_CONFIG_NO_CHAL_CAP_NO_ROOT_CA            20
 #define TEST_CONFIG_MULTIPLE_CERT_IN_DB               21
+#define TEST_CONFIG_DIFF_CERT_IN_DIFF_SLOT            22
 
 #endif

--- a/DeviceSecurityPkg/Test/DeployCert/DeployCert.c
+++ b/DeviceSecurityPkg/Test/DeployCert/DeployCert.c
@@ -566,6 +566,31 @@ MainEntryPoint (
   ASSERT_EFI_ERROR (Status);
   FreePool (ResponderCertChain);
 
+  // Provision the second Spdm CertChain, a valid certificate chain,
+  // but its trust anchor does not match the UEFI device signature variable.
+  ResponderCertChainSize = sizeof (SPDM_CERT_CHAIN) + SHA256_HASH_SIZE + TestCertChain2Size;
+  ResponderCertChain     = AllocateZeroPool (ResponderCertChainSize);
+  ASSERT (ResponderCertChain != NULL);
+  ResponderCertChain->Length   = (UINT16)ResponderCertChainSize;
+  ResponderCertChain->Reserved = 0;
+  Sha256HashAll (TestRootCer2, TestRootCer2Size, (VOID *)(ResponderCertChain + 1));
+
+  CopyMem (
+    (UINT8 *)ResponderCertChain + sizeof (SPDM_CERT_CHAIN) + SHA256_HASH_SIZE,
+    TestCertChain2,
+    TestCertChain2Size
+    );
+
+  Status = gRT->SetVariable (
+                  L"ProvisionSpdmCertChain_2",
+                  &gEfiDeviceSecurityPkgTestConfig,
+                  EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS,
+                  ResponderCertChainSize,
+                  ResponderCertChain
+                  );
+  ASSERT_EFI_ERROR (Status);
+  FreePool (ResponderCertChain);
+
   {
     //
     // TBD - we need only include the root-cert, instead of the CertChain

--- a/DeviceSecurityPkg/Test/PciIoPciDoeStub/PciIoPciDoeStub.c
+++ b/DeviceSecurityPkg/Test/PciIoPciDoeStub/PciIoPciDoeStub.c
@@ -989,6 +989,25 @@ MainEntryPoint (
     HasRspPubCert = FALSE;
   }
 
+  // Change the PublicCertChain in slot_0, keep the above original PublicCertChain in slot_1.
+  if (TestConfig == TEST_CONFIG_DIFF_CERT_IN_DIFF_SLOT) {
+    Status = GetVariable2 (
+              L"ProvisionSpdmCertChain_2",
+              &gEfiDeviceSecurityPkgTestConfig,
+              &CertChain,
+              &CertChainSize
+              );
+    if (!EFI_ERROR (Status)) {
+      HasRspPubCert = TRUE;
+      Parameter.additional_data[0] = 0;
+      SpdmSetData (SpdmContext, SpdmDataLocalPublicCertChain, &Parameter, CertChain, CertChainSize);
+
+      // do not free it
+    } else {
+      HasRspPubCert = FALSE;
+    }
+  }
+
   HasRspPrivKey = TRUE;
 
   Data32 = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP |

--- a/DeviceSecurityPkg/Test/SpdmStub/SpdmStub.c
+++ b/DeviceSecurityPkg/Test/SpdmStub/SpdmStub.c
@@ -250,6 +250,25 @@ MainEntryPoint (
     HasRspPubCert = FALSE;
   }
 
+  // Change the PublicCertChain in slot_0, keep the above original PublicCertChain in slot_1.
+  if (TestConfig == TEST_CONFIG_DIFF_CERT_IN_DIFF_SLOT) {
+    Status = GetVariable2 (
+              L"ProvisionSpdmCertChain_2",
+              &gEfiDeviceSecurityPkgTestConfig,
+              &CertChain,
+              &CertChainSize
+              );
+    if (!EFI_ERROR (Status)) {
+      HasRspPubCert = TRUE;
+      Parameter.additional_data[0] = 0;
+      SpdmSetData (SpdmContext, SpdmDataLocalPublicCertChain, &Parameter, CertChain, CertChainSize);
+
+      // do not free it
+    } else {
+      HasRspPubCert = FALSE;
+    }
+  }
+
   HasRspPrivKey = TRUE;
 
   Data32 = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP |

--- a/DeviceSecurityPkg/Test/TestSpdm/TestSpdm.inf
+++ b/DeviceSecurityPkg/Test/TestSpdm/TestSpdm.inf
@@ -40,3 +40,6 @@
   gSpdmProtocolGuid             ## CONSUME
   gSpdmTestProtocolGuid         ## CONSUME
   gEdkiiDeviceSecurityProtocolGuid   ## CONSUME
+
+[Guids]
+  gEfiDeviceSecurityPkgTestConfig    ## CONSUMES


### PR DESCRIPTION
1. Provision a valid certificate chain without trust anchor to slot_0 of responder.
2. Provision a valid certificate chain with trust anchor to slot_1 of responder.
3. Authentication will select slot_1 to do later CHALLENGE and GET_MEASUREMENTS.

Signed-off-by: Zhao, Zhiqiang <zhiqiang.zhao@intel.com>