### PR TITLE
DeviceSecurityPkg: Record SlotId in Data.

### DIFF
--- a/DeviceSecurityPkg/Library/SpdmSecurityLib/SpdmSecurityLib.c
+++ b/DeviceSecurityPkg/Library/SpdmSecurityLib/SpdmSecurityLib.c
@@ -37,7 +37,7 @@ SpdmDeviceAuthenticationAndMeasurement (
   AuthState = TCG_DEVICE_SECURITY_EVENT_DATA_DEVICE_AUTH_STATE_SUCCESS;
   SlotId = 0;
   if ((SecurityPolicy->AuthenticationPolicy & EDKII_DEVICE_AUTHENTICATION_REQUIRED) != 0) {
-    Status = DoDeviceAuthentication (SpdmDeviceContext, &AuthState, &SlotId);
+    Status = DoDeviceAuthentication (SpdmDeviceContext, &AuthState, &SlotId, SecurityState);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "DoDeviceAuthentication failed - %r\n", Status));
       return Status;
@@ -51,7 +51,7 @@ SpdmDeviceAuthenticationAndMeasurement (
   }
 
   if ((SecurityPolicy->MeasurementPolicy & EDKII_DEVICE_MEASUREMENT_REQUIRED) != 0) {
-    Status = DoDeviceMeasurement (SpdmDeviceContext, IsAuthenticated, SlotId);
+    Status = DoDeviceMeasurement (SpdmDeviceContext, IsAuthenticated, SlotId, SecurityState);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "DoDeviceMeasurement failed - %r\n", Status));
     }

--- a/DeviceSecurityPkg/Library/SpdmSecurityLib/SpdmSecurityLibInterna.h
+++ b/DeviceSecurityPkg/Library/SpdmSecurityLib/SpdmSecurityLibInterna.h
@@ -134,7 +134,8 @@ EFI_STATUS
 DoDeviceMeasurement (
   IN  SPDM_DEVICE_CONTEXT  *SpdmDeviceContext,
   IN  BOOLEAN              IsAuthenticated,
-  IN  UINT8                SlotId
+  IN  UINT8                SlotId,
+  OUT EDKII_DEVICE_SECURITY_STATE   *SecurityState
   );
 
 /**
@@ -146,7 +147,8 @@ EFI_STATUS
 DoDeviceAuthentication (
   IN  SPDM_DEVICE_CONTEXT  *SpdmDeviceContext,
   OUT UINT8                *AuthState,
-  OUT UINT8                *ValidSlotId
+  OUT UINT8                *ValidSlotId,
+  OUT EDKII_DEVICE_SECURITY_STATE   *SecurityState
   );
 
 /**

--- a/DeviceSecurityPkg/Test/Tcg2DumpLog/Tcg2DumpLog.c
+++ b/DeviceSecurityPkg/Test/Tcg2DumpLog/Tcg2DumpLog.c
@@ -551,6 +551,12 @@ DumpTcgDeviceSecurityEventStruct (
         Print (L"        SpdmSlotId    - 0x%02x\n", TcgSpdmCertChain->SpdmSlotId);
         Print (L"        SpdmHashAlgo  - 0x%08x\n", TcgSpdmCertChain->SpdmHashAlgo);
 
+        if (EventDataHeader->Version < TCG_DEVICE_SECURITY_EVENT_DATA_VERSION_2) {
+        } else {
+          if (EventDataHeader2->AuthState == TCG_DEVICE_SECURITY_EVENT_DATA_DEVICE_AUTH_STATE_FAIL_INVALID) {
+            break;
+          }
+        }
         Print (L"        SpdmCertChain:\n");
         SpdmCertChain = (VOID *)(TcgSpdmCertChain + 1);
         Print (L"          Length      - 0x%04x\n", SpdmCertChain->Length);


### PR DESCRIPTION
Per PFP spec, Record NvIndex DEV_SEC (AUTH_FAIL_INVALID, TYPE: CertChain, Data:SlotId)

Signed-off-by: Qi Zhang <qi1.zhang@intel.com>