### PR TITLE
SecurityPkg/DeviceSecurity: Get_digest need record when failed

### DIFF
--- a/SecurityPkg/DeviceSecurity/SpdmSecurityLib/SpdmAuthentication.c
+++ b/SecurityPkg/DeviceSecurity/SpdmSecurityLib/SpdmAuthentication.c
@@ -537,8 +537,11 @@ DoDeviceAuthentication (
     ZeroMem (TotalDigestBuffer, sizeof (TotalDigestBuffer));
     SpdmReturn = SpdmGetDigest (SpdmContext, NULL, &SlotMask, TotalDigestBuffer);
     if ((LIBSPDM_STATUS_IS_ERROR (SpdmReturn)) || ((SlotMask & 0x01) == 0)) {
-      SecurityState->AuthenticationState = EDKII_DEVICE_SECURITY_STATE_ERROR_DEVICE_ERROR;
-      return EFI_DEVICE_ERROR;
+      *AuthState                         = TCG_DEVICE_SECURITY_EVENT_DATA_DEVICE_AUTH_STATE_FAIL_INVALID;
+      SecurityState->AuthenticationState = EDKII_DEVICE_SECURITY_STATE_ERROR_CERTIFIACTE_FAILURE;
+      SlotId = 0;
+      Status                             = ExtendCertificate (SpdmDeviceContext, *AuthState, 0, NULL, NULL, 0, SlotId, SecurityState);
+      return Status;
     }
 
     CertChainSize = sizeof (CertChain);


### PR DESCRIPTION
Get_digest need record AUTH_FAIL_INVALID AuthState with slot_id 0 when failed.