### PR TITLE
OvmfPkg/VmmSpdmVTpm: Updtae the data for vTpm X509 Cert

### DIFF
--- a/OvmfPkg/Library/VmmSpdmVTpm/Vmm.c
+++ b/OvmfPkg/Library/VmmSpdmVTpm/Vmm.c
@@ -169,7 +169,7 @@ InternalDumpData (
   UINTN  Index;
 
   for (Index = 0; Index < Size; Index++) {
-    DEBUG ((DEBUG_INFO, "%02x ", (UINTN)Data[Index]));
+    DEBUG ((DEBUG_INFO, ", 0x%02x ", (UINTN)Data[Index]));
     if (Index == 15) {
       DEBUG ((DEBUG_INFO, "|"));
     }


### PR DESCRIPTION
TDVF needs to add the Country Name, Organization Name, Basic Constraints and change the Common Name to "Intel vTPM TD" for the X509 Cert.