### PR TITLE
CryptoPkg: Fix MbedtlsPkcs7SignedDataVerifySigners

### DIFF
--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs7VerifyCommon.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs7VerifyCommon.c
@@ -271,8 +271,6 @@ MbedTlsPkcs7GetSignersInfoSet (
 
       SignersSet->AuthAttr.len = Len + (TempP - *P);
       SignersSet->AuthAttr.p = *P;
-      *(SignersSet->AuthAttr.p) = 0x31;
-
       *P = TempP + Len;
    } else {
     SignersSet->AuthAttr.p = NULL;
@@ -531,6 +529,7 @@ MbedtlsPkcs7SignedDataVerifySigners (
   mbedtls_pk_context Pk;
   CONST mbedtls_md_info_t *MdInfo;
   INTN HashLen;
+  UINT8 TempAuthAttr;
 
   Pk = Cert->pk;
   ZeroMem(Hash, MBEDTLS_MD_MAX_SIZE);
@@ -541,7 +540,10 @@ MbedtlsPkcs7SignedDataVerifySigners (
   HashLen = mbedtls_md_get_size(MdInfo);
   mbedtls_md (MdInfo, Data, DataLen, Hash);
   if (SignerInfo->AuthAttr.p != NULL) {
+    TempAuthAttr = *(SignerInfo->AuthAttr.p);
+    *(SignerInfo->AuthAttr.p) = 0x31;
     mbedtls_md (MdInfo, SignerInfo->AuthAttr.p, SignerInfo->AuthAttr.len, Hash);
+    *(SignerInfo->AuthAttr.p) = TempAuthAttr;
   }
   Ret = mbedtls_pk_verify (&Pk, MBEDTLS_MD_SHA1, Hash, HashLen, SignerInfo->Sig.p, SignerInfo->Sig.len);
 
@@ -555,7 +557,11 @@ MbedtlsPkcs7SignedDataVerifySigners (
   ZeroMem(Hash, MBEDTLS_MD_MAX_SIZE);
   mbedtls_md (MdInfo, Data, DataLen, Hash);
   if (SignerInfo->AuthAttr.p != NULL) {
+    TempAuthAttr = *(SignerInfo->AuthAttr.p);
+    *(SignerInfo->AuthAttr.p) = 0x31;
     mbedtls_md (MdInfo, SignerInfo->AuthAttr.p, SignerInfo->AuthAttr.len, Hash);
+    *(SignerInfo->AuthAttr.p) = TempAuthAttr;
+    *(SignerInfo->AuthAttr.p) = 0xA0;
   }
   Ret = mbedtls_pk_verify (&Pk, MBEDTLS_MD_SHA256, Hash, HashLen, SignerInfo->Sig.p, SignerInfo->Sig.len);
   if (Ret == 0) {
@@ -567,7 +573,10 @@ MbedtlsPkcs7SignedDataVerifySigners (
   ZeroMem(Hash, MBEDTLS_MD_MAX_SIZE);
   mbedtls_md (MdInfo, Data, DataLen, Hash);
   if (SignerInfo->AuthAttr.p != NULL) {
+    TempAuthAttr = *(SignerInfo->AuthAttr.p);
+    *(SignerInfo->AuthAttr.p) = 0x31;
     mbedtls_md (MdInfo, SignerInfo->AuthAttr.p, SignerInfo->AuthAttr.len, Hash);
+    *(SignerInfo->AuthAttr.p) = TempAuthAttr;
   }
   Ret = mbedtls_pk_verify (&Pk, MBEDTLS_MD_SHA384, Hash, HashLen, SignerInfo->Sig.p, SignerInfo->Sig.len);
   if (Ret == 0) {
@@ -579,7 +588,10 @@ MbedtlsPkcs7SignedDataVerifySigners (
   ZeroMem(Hash, MBEDTLS_MD_MAX_SIZE);
   mbedtls_md (MdInfo, Data, DataLen, Hash);
   if (SignerInfo->AuthAttr.p != NULL) {
+    TempAuthAttr = *(SignerInfo->AuthAttr.p);
+    *(SignerInfo->AuthAttr.p) = 0x31;
     mbedtls_md (MdInfo, SignerInfo->AuthAttr.p, SignerInfo->AuthAttr.len, Hash);
+    *(SignerInfo->AuthAttr.p) = TempAuthAttr;
   }
   Ret = mbedtls_pk_verify (&Pk, MBEDTLS_MD_SHA512, Hash, HashLen, SignerInfo->Sig.p, SignerInfo->Sig.len);
   if (Ret == 0) {


### PR DESCRIPTION
In the pkcs7 spec RFC2315:
```
(For clarity: The IMPLICIT [0] tag in the authenticatedAttributes field is not part of the Attributes value. 
The Attributes value’s tag is SET OF, and the DER encoding of the SET OF tag, rather than of the IMPLICIT [0] tag, is to be
digested along with the length and contents octets of the Attributes value.)
```
That is reason for this PR.

This operation is same with the Openssl code in `PKCS7_signatureVerify `API:
```
        alen = ASN1_item_i2d((ASN1_VALUE *)sk, &abuf,
                             ASN1_ITEM_rptr(PKCS7_ATTR_VERIFY));
```