### PR TITLE
SpdmDeviceSecurityPei: Fix imbalanced DEBUG macro

### DIFF
--- a/DeviceSecurityTestPkg/SpdmDeviceSecurityPei/SpdmDeviceMeasurement.c
+++ b/DeviceSecurityTestPkg/SpdmDeviceSecurityPei/SpdmDeviceMeasurement.c
@@ -27,7 +27,7 @@ InternalDumpData (
   This function returns the SPDM device type for TCG SPDM event.
 
   @param[in]  SpdmContext             The SPDM context for the device.
-  
+
   @return TCG SPDM device type
 **/
 UINT32
@@ -49,7 +49,7 @@ GetSpdmDeviceType (
   This function returns the SPDM device measurement context size for TCG SPDM event.
 
   @param[in]  SpdmContext             The SPDM context for the device.
-  
+
   @return TCG SPDM device measurement context size
 **/
 UINTN
@@ -73,7 +73,7 @@ GetDeviceMeasurementContextSize (
   @param[in]       SpdmContext             The SPDM context for the device.
   @param[in, OUT]  DeviceContext           The TCG SPDM PCI device measurement context.
   @param[in]       DeviceContextSize       The size of TCG SPDM PCI device measurement context.
-  
+
   @retval EFI_SUCCESS      The TCG SPDM PCI device measurement context is returned.
 **/
 EFI_STATUS
@@ -91,7 +91,7 @@ CreatePciDeviceMeasurementContext (
   if (DeviceContextSize != sizeof(*PciContext)) {
     return EFI_BUFFER_TOO_SMALL;
   }
-  
+
   PciIo = SpdmDriverContext->DeviceIo;
   Status = PciIo->Pci.Read (PciIo, EfiPciIoWidthUint8, 0, sizeof(PciData), &PciData);
   ASSERT_EFI_ERROR(Status);
@@ -123,7 +123,7 @@ CreatePciDeviceMeasurementContext (
   @param[in]       SpdmContext             The SPDM context for the device.
   @param[in, OUT]  DeviceContext           The TCG SPDM device measurement context.
   @param[in]       DeviceContextSize       The size of TCG SPDM device measurement context.
-  
+
   @retval EFI_SUCCESS      The TCG SPDM device measurement context is returned.
   @retval EFI_UNSUPPORTED  The TCG SPDM device measurement context is unsupported.
 **/
@@ -145,7 +145,7 @@ CreateDeviceMeasurementContext (
 
 /**
   This function extend the PCI digest from the DvSec register.
-  
+
   @param[in]  SpdmContext             The SPDM context for the device.
   @param[in]  MeasurementRecordLength The length of the SPDM measurement record
   @param[in]  MeasurementRecord       The SPDM measurement record
@@ -189,7 +189,7 @@ ExtendMeasurement (
   SpdmMeasurementBlockDmtfHeader = (VOID *)(SpdmMeasurementBlockCommonHeader + 1);
   Digest = (SpdmMeasurementBlockDmtfHeader + 1);
   DigestSize = MeasurementRecordLength - sizeof(SPDM_MEASUREMENT_BLOCK_DMTF);
-  
+
   DEBUG((DEBUG_INFO, "SpdmMeasurementBlockCommonHeader\n"));
   DEBUG((DEBUG_INFO, "  Index                        - 0x%02x\n", SpdmMeasurementBlockCommonHeader->index));
   DEBUG((DEBUG_INFO, "  MeasurementSpecification     - 0x%02x\n", SpdmMeasurementBlockCommonHeader->measurement_specification));
@@ -289,7 +289,7 @@ ExtendMeasurement (
 
 /**
   This function executes SPDM measurement and extend to TPM.
-  
+
   @param[in]  SpdmContext            The SPDM context for the device.
   @param[out] DeviceSecurityState    The Device Security state associated with the device.
 **/
@@ -325,7 +325,7 @@ SpdmSendReceiveGetMeasurement (
     return Status;
   }
   DEBUG((DEBUG_INFO, "NumberOfBlocks - 0x%x\n", NumberOfBlocks));
-  
+
   for (Index = 1; Index <= NumberOfBlocks; Index++) {
     DEBUG((DEBUG_INFO, "Index - 0x%x\n", Index));
     //
@@ -347,7 +347,7 @@ SpdmSendReceiveGetMeasurement (
       return Status;
     }
 
-    DEBUG((DEBUG_INFO, "ExtendMeasurement...\n", ExtendMeasurement));
+    DEBUG((DEBUG_INFO, "ExtendMeasurement...\n"));
     Status = ExtendMeasurement (SpdmDriverContext, MeasurementRecordLength, MeasurementRecord);
     if (Status != EFI_SUCCESS) {
       return Status;
@@ -359,7 +359,7 @@ SpdmSendReceiveGetMeasurement (
 
 /**
   This function executes SPDM measurement and extend to TPM.
-  
+
   @param[in]  SpdmContext            The SPDM context for the device.
   @param[out] DeviceSecurityState    The Device Security state associated with the device.
 **/
@@ -384,7 +384,7 @@ DoMeasurementViaSpdm (
 
 /**
   The device driver uses this service to measure an SPDM device.
-  
+
   @param[in]  SpdmContext            The SPDM context for the device.
   @param[out] DeviceSecurityState    The Device Security state associated with the device.
 **/


### PR DESCRIPTION
Removes an argument that does not have a print specifier.