### PR TITLE
UefiHostTestPkg/BaseMemoryLibHost: Fix SetMem functions

### DIFF
--- a/HBFA/UefiHostTestPkg/Library/BaseMemoryLibHost/BaseMemoryLibHost.c
+++ b/HBFA/UefiHostTestPkg/Library/BaseMemoryLibHost/BaseMemoryLibHost.c
@@ -32,6 +32,7 @@ SetMem16 (
   IN UINT16  Value
   )
 {
+  Length /= sizeof (Value);
   for (; Length != 0; Length--) {
     ((UINT16*)Buffer)[Length - 1] = Value;
   }
@@ -46,6 +47,7 @@ SetMem32 (
   IN UINT32  Value
   )
 {
+  Length /= sizeof (Value);
   for (; Length != 0; Length--) {
     ((UINT32*)Buffer)[Length - 1] = Value;
   }
@@ -60,6 +62,7 @@ SetMem64 (
   IN UINT64  Value
   )
 {
+  Length /= sizeof (Value);
   for (; Length != 0; Length--) {
     ((UINT64*)Buffer)[Length - 1] = Value;
   }


### PR DESCRIPTION
The Length parameter contains the number of bytes to fill the buffer, so there was an overflow in the SetMem16, SetMem32 and SetMem64 functions. Fixed by dividing the Length parameter by the size of the Value parameter.