### PR TITLE
CryptoPkg: Drop MD5 and SHA-1 digest registration in Pkcs7Verify

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c
@@ -826,14 +826,6 @@ Pkcs7Verify (
   //
   // Register & Initialize necessary digest algorithms for PKCS#7 Handling
   //
-  if (EVP_add_digest (EVP_md5 ()) == 0) {
-    return FALSE;
-  }
-
-  if (EVP_add_digest (EVP_sha1 ()) == 0) {
-    return FALSE;
-  }
-
   if (EVP_add_digest (EVP_sha256 ()) == 0) {
     return FALSE;
   }
@@ -843,10 +835,6 @@ Pkcs7Verify (
   }
 
   if (EVP_add_digest (EVP_sha512 ()) == 0) {
-    return FALSE;
-  }
-
-  if (EVP_add_digest_alias (SN_sha1WithRSAEncryption, SN_sha1WithRSA) == 0) {
     return FALSE;
   }
 


### PR DESCRIPTION
Remove EVP_md5(), EVP_sha1(), and the sha1WithRSA digest alias
from Pkcs7Verify(). MD5 and SHA-1 are considered cryptographically broken and should not be used for PKCS#7 signature verification.
Only SHA-256, SHA-384, and SHA-512 are retained as supported digest algorithms.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>

ref: https://github.com/tianocore/edk2/issues/12406