### PR TITLE
SecurityPkg: Remove SHA-1 image hash support from DxeImageVerificationLib

### DIFF
--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -50,7 +50,6 @@ CONST UINT8  mRsaE[] = { 0x01, 0x00, 0x01 };
 // OID ASN.1 Value for Hash Algorithms
 //
 UINT8  mHashOidValue[] = {
-  0x2B, 0x0E, 0x03, 0x02, 0x1A,                         // OBJ_sha1
   0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x04, // OBJ_sha224
   0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, // OBJ_sha256
   0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x02, // OBJ_sha384
@@ -58,15 +57,10 @@ UINT8  mHashOidValue[] = {
 };
 
 HASH_TABLE  mHash[] = {
- #ifndef DISABLE_SHA1_DEPRECATED_INTERFACES
-  { L"SHA1",   20, &mHashOidValue[0],  5, Sha1GetContextSize,   Sha1Init,   Sha1Update,   Sha1Final   },
- #else
-  { L"SHA1",   20, &mHashOidValue[0],  5, NULL,                 NULL,       NULL,         NULL        },
- #endif
-  { L"SHA224", 28, &mHashOidValue[5],  9, NULL,                 NULL,       NULL,         NULL        },
-  { L"SHA256", 32, &mHashOidValue[14], 9, Sha256GetContextSize, Sha256Init, Sha256Update, Sha256Final },
-  { L"SHA384", 48, &mHashOidValue[23], 9, Sha384GetContextSize, Sha384Init, Sha384Update, Sha384Final },
-  { L"SHA512", 64, &mHashOidValue[32], 9, Sha512GetContextSize, Sha512Init, Sha512Update, Sha512Final }
+  { L"SHA224", 28, &mHashOidValue[0],  9, NULL,                 NULL,       NULL,         NULL        },
+  { L"SHA256", 32, &mHashOidValue[9],  9, Sha256GetContextSize, Sha256Init, Sha256Update, Sha256Final },
+  { L"SHA384", 48, &mHashOidValue[18], 9, Sha384GetContextSize, Sha384Init, Sha384Update, Sha384Final },
+  { L"SHA512", 64, &mHashOidValue[27], 9, Sha512GetContextSize, Sha512Init, Sha512Update, Sha512Final }
 };
 
 EFI_STRING  mHashTypeStr;
@@ -320,13 +314,6 @@ HashPeImage (
   ZeroMem (mImageDigest, MAX_DIGEST_SIZE);
 
   switch (HashAlg) {
- #ifndef DISABLE_SHA1_DEPRECATED_INTERFACES
-    case HASHALG_SHA1:
-      mImageDigestSize = SHA1_DIGEST_SIZE;
-      mCertType        = gEfiCertSha1Guid;
-      break;
- #endif
-
     case HASHALG_SHA256:
       mImageDigestSize = SHA256_DIGEST_SIZE;
       mCertType        = gEfiCertSha256Guid;

--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.h
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.h
@@ -62,12 +62,11 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 // Support hash types
 //
-#define HASHALG_SHA1    0x00000000
-#define HASHALG_SHA224  0x00000001
-#define HASHALG_SHA256  0x00000002
-#define HASHALG_SHA384  0x00000003
-#define HASHALG_SHA512  0x00000004
-#define HASHALG_MAX     0x00000005
+#define HASHALG_SHA224  0x00000000
+#define HASHALG_SHA256  0x00000001
+#define HASHALG_SHA384  0x00000002
+#define HASHALG_SHA512  0x00000003
+#define HASHALG_MAX     0x00000004
 
 //
 // Set max digest size as SHA512 Output (64 bytes) by far

--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.inf
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.inf
@@ -69,10 +69,6 @@
 
   ## SOMETIMES_CONSUMES   ## GUID       # Unique ID for the type of the signature.
   ## SOMETIMES_PRODUCES   ## GUID       # Unique ID for the type of the signature.
-  gEfiCertSha1Guid
-
-  ## SOMETIMES_CONSUMES   ## GUID       # Unique ID for the type of the signature.
-  ## SOMETIMES_PRODUCES   ## GUID       # Unique ID for the type of the signature.
   gEfiCertSha256Guid
 
   ## SOMETIMES_CONSUMES   ## GUID       # Unique ID for the type of the signature.

--- a/SecurityPkg/Library/DxeImageVerificationLib/GoogleTest/DxeImageVerificationLibGoogleTest.inf
+++ b/SecurityPkg/Library/DxeImageVerificationLib/GoogleTest/DxeImageVerificationLibGoogleTest.inf
@@ -48,10 +48,6 @@
 
   ## SOMETIMES_CONSUMES   ## GUID       # Unique ID for the type of the signature.
   ## SOMETIMES_PRODUCES   ## GUID       # Unique ID for the type of the signature.
-  gEfiCertSha1Guid
-
-  ## SOMETIMES_CONSUMES   ## GUID       # Unique ID for the type of the signature.
-  ## SOMETIMES_PRODUCES   ## GUID       # Unique ID for the type of the signature.
   gEfiCertSha256Guid
 
   ## SOMETIMES_CONSUMES   ## GUID       # Unique ID for the type of the signature.


### PR DESCRIPTION
SHA-1 is cryptographically broken and should not be used for image verification. Remove all SHA-1 support from DxeImageVerificationLib:

- Remove SHA-1 OID from `mHashOidValue[]` array
- Remove SHA-1 entry from `mHash[]` table and its `DISABLE_SHA1_DEPRECATED_INTERFACES` ifdef guards
- Remove `HASHALG_SHA1` case from `HashPeImage()` switch
- Renumber `HASHALG_*` defines (SHA224=0, SHA256=1, SHA384=2, SHA512=3, MAX=4)
- Remove `gEfiCertSha1Guid` from both main and GoogleTest INF files

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>


ref: https://github.com/tianocore/edk2/issues/12406