### PR TITLE
SecurityPkg: Add signing OID check for secureboot key enrollment

### DIFF
--- a/CryptoPkg/Driver/Crypto.c
+++ b/CryptoPkg/Driver/Crypto.c
@@ -3210,6 +3210,38 @@ CryptoServiceX509GetSignatureAlgorithm (
 }
 
 /**
+  Retrieve the Signature Algorithm OID string from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     AsciiOid         Null-terminated ASCII dotted-decimal OID buffer.
+  @param[in,out]  AsciiOidSize     On input, the size in bytes of AsciiOid.
+                                   On output, the size of the ASCII OID string,
+                                   including the null terminator.
+
+  @retval TRUE                     The certificate Signature Algorithm OID string was
+                                   retrieved successfully.
+  @retval FALSE                    If Cert is NULL.
+  @retval FALSE                    If AsciiOidSize is NULL.
+  @retval FALSE                    If the certificate is invalid.
+  @retval FALSE                    If no SignatureType exists.
+  @retval FALSE                    If AsciiOid is NULL or the buffer is too small.
+                                   The required size is returned in AsciiOidSize.
+  @retval FALSE                    The operation is not supported.
+**/
+BOOLEAN
+EFIAPI
+CryptoServiceX509GetSignatureAlgorithmAscii (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     CHAR8        *AsciiOid   OPTIONAL,
+  IN OUT  UINTN        *AsciiOidSize
+  )
+{
+  return CALL_BASECRYPTLIB (X509.Services.GetSignatureAlgorithmAscii, X509GetSignatureAlgorithmAscii, (Cert, CertSize, AsciiOid, AsciiOidSize), FALSE);
+}
+
+/**
   Retrieve Extension data from one X.509 certificate.
 
   @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
@@ -7217,4 +7249,6 @@ const EDKII_CRYPTO_PROTOCOL  mEdkiiCrypto = {
   /// Pkcs (Continued)
   CryptoServicePkcs7GetSignerInfoNum,
   CryptoServicePkcs7GetVerifyOidList,
+  /// X509 (Continued)
+  CryptoServiceX509GetSignatureAlgorithmAscii,
 };

--- a/CryptoPkg/Include/Library/BaseCryptLib.h
+++ b/CryptoPkg/Include/Library/BaseCryptLib.h
@@ -2776,6 +2776,35 @@ X509GetSignatureAlgorithm (
   );
 
 /**
+  Retrieve the Signature Algorithm OID string from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     AsciiOid         Null-terminated ASCII dotted-decimal OID buffer.
+  @param[in,out]  AsciiOidSize     On input, the size in bytes of AsciiOid.
+                                   On output, the size of the ASCII OID string,
+                                   including the null terminator.
+
+  @retval TRUE                     The certificate Signature Algorithm OID string was
+                                   retrieved successfully.
+  @retval FALSE                    If Cert is NULL.
+  @retval FALSE                    If AsciiOidSize is NULL.
+  @retval FALSE                    If the certificate is invalid.
+  @retval FALSE                    If no SignatureType exists.
+  @retval FALSE                    If AsciiOid is NULL or the buffer is too small.
+                                   The required size is returned in AsciiOidSize.
+  @retval FALSE                    The operation is not supported.
+**/
+BOOLEAN
+EFIAPI
+X509GetSignatureAlgorithmAscii (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     CHAR8        *AsciiOid   OPTIONAL,
+  IN OUT  UINTN        *AsciiOidSize
+  );
+
+/**
   Retrieve Extension data from one X.509 certificate.
 
   @param[in]      Cert             Pointer to the DER-encoded X509 certificate.

--- a/CryptoPkg/Include/Pcd/PcdCryptoServiceFamilyEnable.h
+++ b/CryptoPkg/Include/Pcd/PcdCryptoServiceFamilyEnable.h
@@ -237,6 +237,7 @@ typedef struct {
       UINT8    GetCertFromCertChain        : 1;
       UINT8    Asn1GetTag                  : 1;
       UINT8    GetExtendedBasicConstraints : 1;
+      UINT8    GetSignatureAlgorithmAscii  : 1;
     } Services;
     UINT32    Family;
   } X509;

--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptX509.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptX509.c
@@ -1333,6 +1333,100 @@ _Exit:
 }
 
 /**
+  Retrieve the Signature Algorithm OID string from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     AsciiOid         Null-terminated ASCII dotted-decimal OID buffer.
+  @param[in,out]  AsciiOidSize     On input, the size in bytes of AsciiOid.
+                                   On output, the size of the ASCII OID string,
+                                   including the null terminator.
+
+  @retval TRUE                     The certificate Signature Algorithm OID string was
+                                   retrieved successfully.
+  @retval FALSE                    If Cert is NULL.
+  @retval FALSE                    If AsciiOidSize is NULL.
+  @retval FALSE                    If the certificate is invalid.
+  @retval FALSE                    If no SignatureType exists.
+  @retval FALSE                    If AsciiOid is NULL or the buffer is too small.
+                                   The required size is returned in AsciiOidSize.
+  @retval FALSE                    The operation is not supported.
+**/
+BOOLEAN
+EFIAPI
+X509GetSignatureAlgorithmAscii (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     CHAR8        *AsciiOid   OPTIONAL,
+  IN OUT  UINTN        *AsciiOidSize
+  )
+{
+  BOOLEAN      Status;
+  X509         *X509Cert;
+  INT32        Nid;
+  ASN1_OBJECT  *Asn1Obj;
+  INT32        TextLength;
+  UINTN        RequiredSize;
+
+  if ((Cert == NULL) || (AsciiOidSize == NULL) || (CertSize == 0)) {
+    return FALSE;
+  }
+
+  X509Cert = NULL;
+  Status   = FALSE;
+
+  Status = X509ConstructCertificate (Cert, CertSize, (UINT8 **)&X509Cert);
+  if ((X509Cert == NULL) || !Status) {
+    Status = FALSE;
+    goto _Exit;
+  }
+
+  Nid = X509_get_signature_nid (X509Cert);
+  if (Nid == NID_undef) {
+    *AsciiOidSize = 0;
+    Status        = FALSE;
+    goto _Exit;
+  }
+
+  Asn1Obj = OBJ_nid2obj (Nid);
+  if (Asn1Obj == NULL) {
+    *AsciiOidSize = 0;
+    Status        = FALSE;
+    goto _Exit;
+  }
+
+  TextLength = OBJ_obj2txt (NULL, 0, Asn1Obj, 1);
+  if (TextLength <= 0) {
+    *AsciiOidSize = 0;
+    Status        = FALSE;
+    goto _Exit;
+  }
+
+  RequiredSize = (UINTN)TextLength + 1;
+  if ((AsciiOid == NULL) || (*AsciiOidSize < RequiredSize)) {
+    *AsciiOidSize = RequiredSize;
+    Status        = FALSE;
+    goto _Exit;
+  }
+
+  if (OBJ_obj2txt (AsciiOid, (INT32)(*AsciiOidSize), Asn1Obj, 1) != TextLength) {
+    *AsciiOidSize = 0;
+    Status        = FALSE;
+    goto _Exit;
+  }
+
+  *AsciiOidSize = RequiredSize;
+  Status        = TRUE;
+
+_Exit:
+  if (X509Cert != NULL) {
+    X509_free (X509Cert);
+  }
+
+  return Status;
+}
+
+/**
   Retrieve Extension data from one X.509 certificate.
 
   @param[in]      Cert             Pointer to the DER-encoded X509 certificate.

--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptX509Null.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptX509Null.c
@@ -449,6 +449,33 @@ X509GetSignatureAlgorithm (
 }
 
 /**
+  Retrieve the Signature Algorithm OID string from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     AsciiOid         Null-terminated ASCII dotted-decimal OID buffer.
+  @param[in,out]  AsciiOidSize     On input, the size in bytes of AsciiOid.
+                                   On output, the size of the ASCII OID string,
+                                   including the null terminator.
+
+  @retval TRUE                     The certificate Signature Algorithm OID string was
+                                   retrieved successfully.
+  @retval FALSE                    The operation is not supported.
+**/
+BOOLEAN
+EFIAPI
+X509GetSignatureAlgorithmAscii (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     CHAR8        *AsciiOid   OPTIONAL,
+  IN OUT  UINTN        *AsciiOidSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
   Retrieve Extension data from one X.509 certificate.
 
   @param[in]      Cert             Pointer to the DER-encoded X509 certificate.

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptX509.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptX509.c
@@ -1296,6 +1296,39 @@ Cleanup:
 }
 
 /**
+  Retrieve the Signature Algorithm OID string from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     AsciiOid         Null-terminated ASCII dotted-decimal OID buffer.
+  @param[in,out]  AsciiOidSize     On input, the size in bytes of AsciiOid.
+                                   On output, the size of the ASCII OID string,
+                                   including the null terminator.
+
+  @retval TRUE                     The certificate Signature Algorithm OID string was
+                                   retrieved successfully.
+  @retval FALSE                    If Cert is NULL.
+  @retval FALSE                    If AsciiOidSize is NULL.
+  @retval FALSE                    If the certificate is invalid.
+  @retval FALSE                    If no SignatureType exists.
+  @retval FALSE                    If AsciiOid is NULL or the buffer is too small.
+                                   The required size is returned in AsciiOidSize.
+  @retval FALSE                    The operation is not supported.
+**/
+BOOLEAN
+EFIAPI
+X509GetSignatureAlgorithmAscii (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     CHAR8        *AsciiOid   OPTIONAL,
+  IN OUT  UINTN        *AsciiOidSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
  Find first Extension data match with given OID
 
   @param[in]      Start             Pointer to the DER-encoded Extensions Data

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptX509Null.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptX509Null.c
@@ -449,6 +449,33 @@ X509GetSignatureAlgorithm (
 }
 
 /**
+  Retrieve the Signature Algorithm OID string from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     AsciiOid         Null-terminated ASCII dotted-decimal OID buffer.
+  @param[in,out]  AsciiOidSize     On input, the size in bytes of AsciiOid.
+                                   On output, the size of the ASCII OID string,
+                                   including the null terminator.
+
+  @retval TRUE                     The certificate Signature Algorithm OID string was
+                                   retrieved successfully.
+  @retval FALSE                    The operation is not supported.
+**/
+BOOLEAN
+EFIAPI
+X509GetSignatureAlgorithmAscii (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     CHAR8        *AsciiOid   OPTIONAL,
+  IN OUT  UINTN        *AsciiOidSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
   Retrieve Extension data from one X.509 certificate.
 
   @param[in]      Cert             Pointer to the DER-encoded X509 certificate.

--- a/CryptoPkg/Library/BaseCryptLibNull/Pk/CryptX509Null.c
+++ b/CryptoPkg/Library/BaseCryptLibNull/Pk/CryptX509Null.c
@@ -449,6 +449,33 @@ X509GetSignatureAlgorithm (
 }
 
 /**
+  Retrieve the Signature Algorithm OID string from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     AsciiOid         Null-terminated ASCII dotted-decimal OID buffer.
+  @param[in,out]  AsciiOidSize     On input, the size in bytes of AsciiOid.
+                                   On output, the size of the ASCII OID string,
+                                   including the null terminator.
+
+  @retval TRUE                     The certificate Signature Algorithm OID string was
+                                   retrieved successfully.
+  @retval FALSE                    The operation is not supported.
+**/
+BOOLEAN
+EFIAPI
+X509GetSignatureAlgorithmAscii (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     CHAR8        *AsciiOid   OPTIONAL,
+  IN OUT  UINTN        *AsciiOidSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
   Retrieve Extension data from one X.509 certificate.
 
   @param[in]      Cert             Pointer to the DER-encoded X509 certificate.

--- a/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/CryptLib.c
+++ b/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/CryptLib.c
@@ -2446,6 +2446,38 @@ X509GetSignatureAlgorithm (
 }
 
 /**
+  Retrieve the Signature Algorithm OID string from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     AsciiOid         Null-terminated ASCII dotted-decimal OID buffer.
+  @param[in,out]  AsciiOidSize     On input, the size in bytes of AsciiOid.
+                                   On output, the size of the ASCII OID string,
+                                   including the null terminator.
+
+  @retval TRUE                     The certificate Signature Algorithm OID string was
+                                   retrieved successfully.
+  @retval FALSE                    If Cert is NULL.
+  @retval FALSE                    If AsciiOidSize is NULL.
+  @retval FALSE                    If the certificate is invalid.
+  @retval FALSE                    If no SignatureType exists.
+  @retval FALSE                    If AsciiOid is NULL or the buffer is too small.
+                                   The required size is returned in AsciiOidSize.
+  @retval FALSE                    The operation is not supported.
+**/
+BOOLEAN
+EFIAPI
+X509GetSignatureAlgorithmAscii (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     CHAR8        *AsciiOid   OPTIONAL,
+  IN OUT  UINTN        *AsciiOidSize
+  )
+{
+  CALL_CRYPTO_SERVICE (X509GetSignatureAlgorithmAscii, (Cert, CertSize, AsciiOid, AsciiOidSize), FALSE);
+}
+
+/**
   Retrieve Extension data from one X.509 certificate.
 
   @param[in]      Cert             Pointer to the DER-encoded X509 certificate.

--- a/CryptoPkg/Private/Protocol/Crypto.h
+++ b/CryptoPkg/Private/Protocol/Crypto.h
@@ -21,7 +21,7 @@
 /// the EDK II Crypto Protocol is extended, this version define must be
 /// increased.
 ///
-#define EDKII_CRYPTO_VERSION  20
+#define EDKII_CRYPTO_VERSION  21
 
 ///
 /// EDK II Crypto Protocol forward declaration
@@ -2608,6 +2608,35 @@ BOOLEAN
   IN       UINTN CertSize,
   OUT   UINT8 *Oid, OPTIONAL
   IN OUT   UINTN       *OidSize
+  );
+
+/**
+  Retrieve the Signature Algorithm OID string from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     AsciiOid         Null-terminated ASCII dotted-decimal OID buffer.
+  @param[in,out]  AsciiOidSize     On input, the size in bytes of AsciiOid.
+                                   On output, the size of the ASCII OID string,
+                                   including the null terminator.
+
+  @retval TRUE                     The certificate Signature Algorithm OID string was
+                                   retrieved successfully.
+  @retval FALSE                    If Cert is NULL.
+  @retval FALSE                    If AsciiOidSize is NULL.
+  @retval FALSE                    If the certificate is invalid.
+  @retval FALSE                    If no SignatureType exists.
+  @retval FALSE                    If AsciiOid is NULL or the buffer is too small.
+                                   The required size is returned in AsciiOidSize.
+  @retval FALSE                    The operation is not supported.
+**/
+typedef
+BOOLEAN
+(EFIAPI *EDKII_CRYPTO_X509_GET_SIGNATURE_ALGORITHM_ASCII)(
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     CHAR8        *AsciiOid   OPTIONAL,
+  IN OUT  UINTN        *AsciiOidSize
   );
 
 /**
@@ -5798,6 +5827,8 @@ struct _EDKII_CRYPTO_PROTOCOL {
   /// Pkcs (Continued)
   EDKII_CRYPTO_PKCS7_GET_SIGNERINFO_NUM               Pkcs7GetSignerInfoNum;
   EDKII_CRYPTO_PKCS7_GET_VERIFY_OID_LIST              Pkcs7GetVerifyOidList;
+  /// X509 (Continued)
+  EDKII_CRYPTO_X509_GET_SIGNATURE_ALGORITHM_ASCII     X509GetSignatureAlgorithmAscii;
 };
 
 extern GUID  gEdkiiCryptoProtocolGuid;

--- a/SecurityPkg/Library/AuthVariableLib/AuthService.c
+++ b/SecurityPkg/Library/AuthVariableLib/AuthService.c
@@ -498,6 +498,129 @@ UpdatePlatformMode (
 }
 
 /**
+  Check if an ASCII OID exactly exists in a CSV list.
+
+  @param[in]  OidCsv     Null-terminated comma-separated ASCII OID list.
+  @param[in]  AsciiOid   Null-terminated ASCII OID to match.
+
+  @retval TRUE           OID exists in the CSV list as an exact token.
+  @retval FALSE          OID does not exist, or input is invalid.
+**/
+STATIC
+BOOLEAN
+IsAsciiOidInCsvList (
+  IN  CONST CHAR8  *OidCsv,
+  IN  CONST CHAR8  *AsciiOid
+  )
+{
+  CONST CHAR8  *TokenStart;
+  CONST CHAR8  *TokenEnd;
+  UINTN        OidLen;
+  UINTN        TokenLen;
+
+  if ((OidCsv == NULL) || (AsciiOid == NULL) || (*AsciiOid == '\0')) {
+    return FALSE;
+  }
+
+  DEBUG ((DEBUG_INFO, "IsAsciiOidInCsvList - OidCsv=%a\n", OidCsv));
+  DEBUG ((DEBUG_INFO, "IsAsciiOidInCsvList - AsciiOid=%a\n", AsciiOid));
+
+  OidLen     = AsciiStrLen (AsciiOid);
+  TokenStart = OidCsv;
+  while (*TokenStart != '\0') {
+    while (*TokenStart == ',') {
+      TokenStart++;
+    }
+
+    if (*TokenStart == '\0') {
+      //
+      // End with comma
+      //
+      break;
+    }
+
+    TokenEnd = TokenStart;
+    while ((*TokenEnd != '\0') && (*TokenEnd != ',')) {
+      TokenEnd++;
+    }
+
+    TokenLen = (UINTN)(TokenEnd - TokenStart);
+    if ((TokenLen == OidLen) && (CompareMem (TokenStart, AsciiOid, OidLen) == 0)) {
+      DEBUG ((DEBUG_INFO, "IsAsciiOidInCsvList - OID matched successfully\n"));
+      return TRUE;
+    }
+
+    if (*TokenEnd == '\0') {
+      break;
+    }
+
+    TokenStart = TokenEnd + 1;
+  }
+
+  DEBUG ((DEBUG_INFO, "IsAsciiOidInCsvList - OID not found in CSV list\n"));
+  return FALSE;
+}
+
+/**
+  Check if X.509 certificate signing algorithm is supported or not.
+
+  Extracts the signature algorithm OID from an X.509 certificate and verifies
+  it is present in the supported OID list returned by Pkcs7GetVerifyOidList().
+
+  @param[in]  CertData     Pointer to the DER-encoded X.509 certificate.
+  @param[in]  CertDataLen  Length of the certificate data in bytes.
+
+  @retval TRUE             The certificate's signing algorithm is supported.
+  @retval FALSE            The certificate's signing algorithm is not supported,
+                           or an error occurred.
+**/
+STATIC
+BOOLEAN
+IsX509SigningAlgSupported (
+  IN  CONST UINT8  *CertData,
+  IN  UINTN        CertDataLen
+  )
+{
+  CONST CHAR8  *SupportedOidCsv;
+  CHAR8        *AsciiOid;
+  UINTN        AsciiOidSize;
+  BOOLEAN      IsSupported;
+
+  if ((CertData == NULL) || (CertDataLen == 0)) {
+    return FALSE;
+  }
+
+  SupportedOidCsv = Pkcs7GetVerifyOidList (Pkcs7SignatureAlgoAll);
+  if (SupportedOidCsv == NULL) {
+    return FALSE;
+  }
+
+  AsciiOidSize = 0;
+  if (X509GetSignatureAlgorithmAscii (CertData, CertDataLen, NULL, &AsciiOidSize) || (AsciiOidSize == 0)) {
+    return FALSE;
+  }
+
+  AsciiOid = AllocateZeroPool (AsciiOidSize);
+  if (AsciiOid == NULL) {
+    return FALSE;
+  }
+
+  if (!X509GetSignatureAlgorithmAscii (CertData, CertDataLen, AsciiOid, &AsciiOidSize)) {
+    FreePool (AsciiOid);
+    return FALSE;
+  }
+
+  //
+  // OID list is one continuous NULL-terminated CSV (Comma-Separated Values) string.
+  //
+  IsSupported = IsAsciiOidInCsvList (SupportedOidCsv, AsciiOid);
+
+  FreePool (AsciiOid);
+
+  return IsSupported;
+}
+
+/**
   Check input data form to make sure it is a valid EFI_SIGNATURE_LIST for PK/KEK/db/dbx/dbt variable.
 
   @param[in]  VariableName                Name of Variable to be check.
@@ -606,6 +729,14 @@ CheckSignatureListFormat (
       if (!IsValidAlg) {
         DEBUG ((DEBUG_ERROR, "CheckSignatureListFormat - X509 Cert invalid\n"));
         return EFI_INVALID_PARAMETER;
+      }
+
+      //
+      // Check if the certificate's signing algorithm is in the supported OID list.
+      //
+      if (!IsX509SigningAlgSupported (CertData->SignatureData, CertLen)) {
+        DEBUG ((DEBUG_ERROR, "CheckSignatureListFormat - X509 signing alg not in supported list\n"));
+        return EFI_UNSUPPORTED;
       }
     }
 


### PR DESCRIPTION
Code First: https://github.com/tianocore/edk2/issues/12455

Validate X.509 certificate signing algorithms against the Authenticated
Variable OID CSV list returned by Pkcs7GetVerifyOidList()
during enrollment.

Test:
1. No regressions found in Emulator, ECIT check log is correct:
```
IsAsciiOidInCsvList - OidCsv=1.2.840.113549.1.1.11,1.2.840.113549.1.1.12,1.2.840.113549.1.1.13,1.2.840.10045.4.3.2,1.2.840.10045.4.3.3,1.2.840.10045.4.3.4,2.16.840.1.101.3.4.3.17,2.16.840.1.101.3.4.3.18,2.16.840.1.101.3.4.3.19
IsAsciiOidInCsvList - AsciiOid=2.16.840.1.101.3.4.3.19
IsAsciiOidInCsvList - OID matched successfully
```
2. Key enrollment is FAILED correctly if remove OID of ml-dsa-87 in mPkcs7VerifyAllOids:
```
IsAsciiOidInCsvList - OidCsv=1.2.840.113549.1.1.11,1.2.840.113549.1.1.12,1.2.840.113549.1.1.13,1.2.840.10045.4.3.2,1.2.840.10045.4.3.3,1.2.840.10045.4.3.4,2.16.840.1.101.3.4.3.17,2.16.840.1.101.3.4.3.18
IsAsciiOidInCsvList - AsciiOid=2.16.840.1.101.3.4.3.19
IsAsciiOidInCsvList - OID not found in CSV list
CheckSignatureListFormat - X509 signing alg not in ECIT
UpdateSecureBootVariable: Failed to update 'PK': Unsupported
```