### PR TITLE
RedfishPkg: Add Redfish Resource Protocol for platform data provisioning

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -24,9 +24,6 @@
 #
 ##
 
-merge_queue:
-  max_parallel_checks: 1
-
 queue_rules:
   - name: default
     queue_conditions:

--- a/RedfishPkg/Include/Library/RedfishResourceLib.h
+++ b/RedfishPkg/Include/Library/RedfishResourceLib.h
@@ -1,0 +1,61 @@
+/** @file
+  Redfish Resource Library interface.
+
+  Type-agnostic consumer library for retrieving resource data from
+  EFI_REDFISH_RESOURCE_PROTOCOL. The caller is responsible for
+  knowing the element type and size for the given ResourceTypeName.
+
+  Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef REDFISH_RESOURCE_LIB_H_
+#define REDFISH_RESOURCE_LIB_H_
+
+#include <Uefi.h>
+
+/**
+  Get the count of elements for a given resource type.
+
+  @param[in]   ResourceTypeName  ASCII string identifying the resource type
+                                 (e.g., "Memory", "PCIeDevice", "Drive").
+  @param[in]   ElementSize       Size in bytes of one element in the array.
+  @param[out]  Count             Number of elements.
+
+  @retval EFI_SUCCESS            Count returned successfully.
+  @retval EFI_NOT_FOUND          No data for this type.
+  @retval EFI_INVALID_PARAMETER  ResourceTypeName or Count is NULL, or ElementSize is 0.
+**/
+EFI_STATUS
+RedfishResourceGetCount (
+  IN  CHAR8   *ResourceTypeName,
+  IN  UINTN   ElementSize,
+  OUT UINTN   *Count
+  );
+
+/**
+  Get a pointer to the Nth element for a given resource type.
+
+  The returned pointer points into a library-cached copy of the data.
+  The caller must cast it to the appropriate CS struct type.
+  The pointer remains valid until a different ResourceTypeName is requested.
+
+  @param[in]   ResourceTypeName  ASCII string identifying the resource type.
+  @param[in]   ElementSize       Size in bytes of one element in the array.
+  @param[in]   Index             Zero-based index of the element to retrieve.
+  @param[out]  Entry             Pointer to the element.
+
+  @retval EFI_SUCCESS            Entry returned successfully.
+  @retval EFI_NOT_FOUND          No data, or Index out of range.
+  @retval EFI_INVALID_PARAMETER  ResourceTypeName or Entry is NULL, or ElementSize is 0.
+**/
+EFI_STATUS
+RedfishResourceGetEntry (
+  IN  CHAR8   *ResourceTypeName,
+  IN  UINTN   ElementSize,
+  IN  UINTN   Index,
+  OUT VOID    **Entry
+  );
+
+#endif // REDFISH_RESOURCE_LIB_H_

--- a/RedfishPkg/Include/Protocol/RedfishResourceProtocol.h
+++ b/RedfishPkg/Include/Protocol/RedfishResourceProtocol.h
@@ -1,0 +1,113 @@
+/** @file
+  EFI Redfish Resource Protocol definition.
+
+  Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef EFI_REDFISH_RESOURCE_PROTOCOL_H_
+#define EFI_REDFISH_RESOURCE_PROTOCOL_H_
+
+#include <Uefi.h>
+
+#define EFI_REDFISH_RESOURCE_PROTOCOL_GUID \
+  { \
+    0x574527BC, 0xB976, 0x0816, { 0xA1, 0x3B, 0x91, 0xBD, 0x9C, 0x9B, 0xA8, 0x99 } \
+  }
+
+typedef struct _EFI_REDFISH_RESOURCE_PROTOCOL EFI_REDFISH_RESOURCE_PROTOCOL;
+
+/**
+  Returns the Redfish resource types provided by the platform.
+
+  @param[in]   This                Pointer to protocol instance.
+  @param[out]  ResourceTypeCount   Number of supported Redfish data models.
+  @param[out]  SupportedResources  Array of NULL-terminated ASCII strings.
+                                   Caller frees the array and each string.
+
+  @retval EFI_SUCCESS           List returned successfully.
+  @retval EFI_INVALID_PARAMETER This, ResourceTypeCount, or SupportedResources is NULL.
+  @retval EFI_OUT_OF_RESOURCES  Memory allocation failed.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EFI_REDFISH_RESOURCE_GET_SUPPORTED_RESOURCE_TYPES)(
+  IN  EFI_REDFISH_RESOURCE_PROTOCOL  *This,
+  OUT UINTN                          *ResourceTypeCount,
+  OUT CHAR8                          ***SupportedResources
+  );
+
+/**
+  Collect the resource data for a specified Redfish resource type.
+
+  @param[in]   This              Pointer to protocol instance.
+  @param[in]   ResourceTypeName  NULL-terminated ASCII string identifying the resource type.
+  @param[out]  MajorVersion      Schema major version string, or NULL.
+  @param[out]  MinorVersion      Schema minor version string, or NULL.
+  @param[out]  ErrataVersion     Schema errata version string, or NULL.
+  @param[out]  DataSize          Size in bytes of the returned resource data.
+  @param[out]  Data              Pointer to internal resource data. Caller must NOT free.
+
+  @retval EFI_SUCCESS            Data returned successfully.
+  @retval EFI_UNSUPPORTED        The specified resource type is not supported.
+  @retval EFI_NOT_FOUND          No resource data available for this type.
+  @retval EFI_INVALID_PARAMETER  This or ResourceTypeName is NULL.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EFI_REDFISH_RESOURCE_GET_RESOURCE)(
+  IN  EFI_REDFISH_RESOURCE_PROTOCOL  *This,
+  IN  CHAR8                          *ResourceTypeName,
+  OUT CHAR8                          **MajorVersion      OPTIONAL,
+  OUT CHAR8                          **MinorVersion      OPTIONAL,
+  OUT CHAR8                          **ErrataVersion     OPTIONAL,
+  OUT UINTN                          *DataSize,
+  OUT VOID                           **Data
+  );
+
+/**
+  Sets the Redfish resource for a specified resource type and schema version.
+
+  The protocol takes ownership of the memory buffer pointed to by Data.
+  The caller must not free, reuse, or modify this memory after calling
+  this function.
+
+  If DataSize is 0 and Data is NULL, the existing resource for the
+  specified ResourceTypeName is removed.
+
+  @param[in]  This              Pointer to protocol instance.
+  @param[in]  ResourceTypeName  NULL-terminated ASCII string identifying the resource type.
+  @param[in]  MajorVersion      Schema major version string, or NULL.
+  @param[in]  MinorVersion      Schema minor version string, or NULL.
+  @param[in]  ErrataVersion     Schema errata version string, or NULL.
+  @param[in]  DataSize          Size in bytes of Data. 0 to remove existing data.
+  @param[in]  Data              Pointer to resource data. NULL if DataSize is 0.
+
+  @retval EFI_SUCCESS            Data set successfully.
+  @retval EFI_INVALID_PARAMETER  This or ResourceTypeName is NULL,
+                                 DataSize > 0 and Data is NULL,
+                                 or DataSize = 0 and Data is not NULL.
+  @retval EFI_OUT_OF_RESOURCES   Memory allocation failed.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EFI_REDFISH_RESOURCE_SET_RESOURCE)(
+  IN  EFI_REDFISH_RESOURCE_PROTOCOL  *This,
+  IN  CHAR8                          *ResourceTypeName,
+  IN  CHAR8                          *MajorVersion      OPTIONAL,
+  IN  CHAR8                          *MinorVersion      OPTIONAL,
+  IN  CHAR8                          *ErrataVersion     OPTIONAL,
+  IN  UINTN                          DataSize,
+  IN  VOID                           *Data              OPTIONAL
+  );
+
+struct _EFI_REDFISH_RESOURCE_PROTOCOL {
+  EFI_REDFISH_RESOURCE_GET_SUPPORTED_RESOURCE_TYPES  GetSupportedResourceTypes;
+  EFI_REDFISH_RESOURCE_GET_RESOURCE                  GetResource;
+  EFI_REDFISH_RESOURCE_SET_RESOURCE                  SetResource;
+};
+
+extern EFI_GUID  gEfiRedfishResourceProtocolGuid;
+
+#endif

--- a/RedfishPkg/Library/RedfishResourceLib/RedfishResourceLib.c
+++ b/RedfishPkg/Library/RedfishResourceLib/RedfishResourceLib.c
@@ -1,0 +1,192 @@
+/** @file
+  RedfishResourceLib - type-agnostic consumer side library.
+
+  Retrieves resource data from EFI_REDFISH_RESOURCE_PROTOCOL
+  and provides count/entry access for Redfish feature drivers.
+
+  Note: GetResource() returns a callee-allocated copy. This library
+  caches the last retrieved data to avoid repeated allocations within
+  the same boot phase. The cache is invalidated when a different
+  ResourceTypeName is requested.
+
+  Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/RedfishResourceLib.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Protocol/RedfishResourceProtocol.h>
+
+//
+// Cache the last GetResource result to avoid repeated allocations
+//
+STATIC CHAR8  *mCachedTypeName = NULL;
+STATIC VOID   *mCachedData     = NULL;
+STATIC UINTN  mCachedDataSize  = 0;
+
+/**
+  Locate the EFI_REDFISH_RESOURCE_PROTOCOL.
+**/
+STATIC
+EFI_STATUS
+LocateResourceProtocol (
+  OUT EFI_REDFISH_RESOURCE_PROTOCOL  **Protocol
+  )
+{
+  return gBS->LocateProtocol (
+                &gEfiRedfishResourceProtocolGuid,
+                NULL,
+                (VOID **)Protocol
+                );
+}
+
+/**
+  Internal helper: ensure we have cached data for the given type.
+  If the cache already holds data for this type, reuse it.
+  Otherwise, call GetResource() and cache the result.
+**/
+STATIC
+EFI_STATUS
+EnsureCachedData (
+  IN  CHAR8  *ResourceTypeName
+  )
+{
+  EFI_STATUS                     Status;
+  EFI_REDFISH_RESOURCE_PROTOCOL  *Protocol;
+
+  //
+  // If already cached for this type, nothing to do
+  //
+  if ((mCachedTypeName != NULL) &&
+      (AsciiStrCmp (mCachedTypeName, ResourceTypeName) == 0) &&
+      (mCachedData != NULL))
+  {
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Free previous cache
+  //
+  if (mCachedData != NULL) {
+    FreePool (mCachedData);
+    mCachedData = NULL;
+  }
+  if (mCachedTypeName != NULL) {
+    FreePool (mCachedTypeName);
+    mCachedTypeName = NULL;
+  }
+  mCachedDataSize = 0;
+
+  Status = LocateResourceProtocol (&Protocol);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_INFO, "%a: Protocol not found: %r\n", __func__, Status));
+    return Status;
+  }
+
+  Status = Protocol->GetResource (
+                       Protocol,
+                       ResourceTypeName,
+                       NULL, NULL, NULL,
+                       &mCachedDataSize,
+                       &mCachedData
+                       );
+  if (EFI_ERROR (Status)) {
+    mCachedData     = NULL;
+    mCachedDataSize = 0;
+    return Status;
+  }
+
+  mCachedTypeName = AllocateCopyPool (AsciiStrSize (ResourceTypeName), ResourceTypeName);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Get the count of elements for a given resource type.
+
+  @param[in]   ResourceTypeName  ASCII string identifying the resource type.
+  @param[in]   ElementSize       Size in bytes of one element in the array.
+  @param[out]  Count             Number of elements.
+
+  @retval EFI_SUCCESS            Count returned successfully.
+  @retval EFI_NOT_FOUND          No data for this type.
+  @retval EFI_INVALID_PARAMETER  ResourceTypeName or Count is NULL, or ElementSize is 0.
+**/
+EFI_STATUS
+RedfishResourceGetCount (
+  IN  CHAR8   *ResourceTypeName,
+  IN  UINTN   ElementSize,
+  OUT UINTN   *Count
+  )
+{
+  EFI_STATUS  Status;
+
+  if ((ResourceTypeName == NULL) || (Count == NULL) || (ElementSize == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *Count = 0;
+
+  Status = EnsureCachedData (ResourceTypeName);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  *Count = mCachedDataSize / ElementSize;
+
+  DEBUG ((DEBUG_INFO, "%a: %a count = %u (DataSize=%u, ElementSize=%u)\n",
+          __func__, ResourceTypeName, *Count, mCachedDataSize, ElementSize));
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Get a pointer to the Nth element for a given resource type.
+
+  @param[in]   ResourceTypeName  ASCII string identifying the resource type.
+  @param[in]   ElementSize       Size in bytes of one element in the array.
+  @param[in]   Index             Zero-based index of the element to retrieve.
+  @param[out]  Entry             Pointer to the element.
+
+  @retval EFI_SUCCESS            Entry returned successfully.
+  @retval EFI_NOT_FOUND          No data, or Index out of range.
+  @retval EFI_INVALID_PARAMETER  ResourceTypeName or Entry is NULL, or ElementSize is 0.
+**/
+EFI_STATUS
+RedfishResourceGetEntry (
+  IN  CHAR8   *ResourceTypeName,
+  IN  UINTN   ElementSize,
+  IN  UINTN   Index,
+  OUT VOID    **Entry
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       ElementCount;
+
+  if ((ResourceTypeName == NULL) || (Entry == NULL) || (ElementSize == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *Entry = NULL;
+
+  Status = EnsureCachedData (ResourceTypeName);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  ElementCount = mCachedDataSize / ElementSize;
+  if (Index >= ElementCount) {
+    DEBUG ((DEBUG_ERROR, "%a: Index %u out of range (count=%u)\n",
+            __func__, Index, ElementCount));
+    return EFI_NOT_FOUND;
+  }
+
+  *Entry = (UINT8 *)mCachedData + (Index * ElementSize);
+
+  return EFI_SUCCESS;
+}

--- a/RedfishPkg/Library/RedfishResourceLib/RedfishResourceLib.inf
+++ b/RedfishPkg/Library/RedfishResourceLib/RedfishResourceLib.inf
@@ -1,0 +1,35 @@
+## @file
+#  RedfishResourceLib - type-agnostic consumer side library.
+#
+#  Provides resource query APIs for Redfish feature drivers.
+#  Retrieves data from EFI_REDFISH_RESOURCE_PROTOCOL.
+#
+#  Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001000b
+  BASE_NAME                      = RedfishResourceLib
+  FILE_GUID                      = 8EC5A919-320C-424D-8FAF-0F7F4223ACD7
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = RedfishResourceLib
+
+[Sources]
+  RedfishResourceLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  RedfishPkg/RedfishPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MemoryAllocationLib
+  UefiBootServicesTableLib
+
+[Protocols]
+  gEfiRedfishResourceProtocolGuid    ## CONSUMES

--- a/RedfishPkg/Redfish.fdf.inc
+++ b/RedfishPkg/Redfish.fdf.inc
@@ -21,4 +21,5 @@
   INF RedfishPkg/RedfishPlatformConfigDxe/RedfishPlatformConfigDxe.inf
   INF MdeModulePkg/Universal/RegularExpressionDxe/RegularExpressionDxe.inf
   INF RedfishPkg/RedfishHttpDxe/RedfishHttpDxe.inf
+  INF RedfishPkg/RedfishResourceDxe/RedfishResourceDxe.inf
 !endif

--- a/RedfishPkg/RedfishComponents.dsc.inc
+++ b/RedfishPkg/RedfishComponents.dsc.inc
@@ -29,4 +29,5 @@
   RedfishPkg/RedfishPlatformConfigDxe/RedfishPlatformConfigDxe.inf
   MdeModulePkg/Universal/RegularExpressionDxe/RegularExpressionDxe.inf
   RedfishPkg/RedfishHttpDxe/RedfishHttpDxe.inf
+  RedfishPkg/RedfishResourceDxe/RedfishResourceDxe.inf
 !endif

--- a/RedfishPkg/RedfishLibs.dsc.inc
+++ b/RedfishPkg/RedfishLibs.dsc.inc
@@ -22,5 +22,6 @@
   HiiUtilityLib|RedfishPkg/Library/HiiUtilityLib/HiiUtilityLib.inf
   RedfishPlatformConfigLib|RedfishPkg/Library/RedfishPlatformConfigLib/RedfishPlatformConfigLib.inf
   RedfishHttpLib|RedfishPkg/Library/RedfishHttpLib/RedfishHttpLib.inf
+  RedfishResourceLib|RedfishPkg/Library/RedfishResourceLib/RedfishResourceLib.inf
 !endif
 

--- a/RedfishPkg/RedfishPkg.dec
+++ b/RedfishPkg/RedfishPkg.dec
@@ -80,6 +80,11 @@
   #
   RedfishPlatformWantedDeviceLib|Include/Library/RedfishPlatformWantedDeviceLib.h
 
+  ##  @libraryclass  Type-agnostic consumer library for retrieving resource
+  #   data from EFI_REDFISH_RESOURCE_PROTOCOL.
+  #
+  RedfishResourceLib|Include/Library/RedfishResourceLib.h
+
 [LibraryClasses.Common.Private]
   ##  @libraryclass  Provides the private C runtime library functions.
   #   CRT library is currently used by edk2 JsonLib (open source
@@ -109,6 +114,9 @@
 
   ## Include/Protocol/EdkIIRedfishHttpProtocol.h
   gEdkIIRedfishHttpProtocolGuid = { 0x58a0f47e, 0xf45f, 0x4d44, { 0x89, 0x5b, 0x2a, 0xfe, 0xb0, 0x80, 0x15, 0xe2 } }
+
+  ## Include/Protocol/RedfishResourceProtocol.h
+  gEfiRedfishResourceProtocolGuid = { 0x574527BC, 0xB976, 0x0816, { 0xA1, 0x3B, 0x91, 0xBD, 0x9C, 0x9B, 0xA8, 0x99 } }
 
 [Guids]
   gEfiRedfishPkgTokenSpaceGuid      = { 0x4fdbccb7, 0xe829, 0x4b4c, { 0x88, 0x87, 0xb2, 0x3f, 0xd7, 0x25, 0x4b, 0x85 }}

--- a/RedfishPkg/RedfishPkg.dsc
+++ b/RedfishPkg/RedfishPkg.dsc
@@ -69,5 +69,6 @@
   RedfishPkg/Library/RedfishPlatformConfigLib/RedfishPlatformConfigLib.inf
   RedfishPkg/Library/RedfishHttpLib/RedfishHttpLib.inf
   RedfishPkg/Library/RedfishPlatformWantedDeviceLibNull/RedfishPlatformWantedDeviceLibNull.inf
+  RedfishPkg/Library/RedfishResourceLib/RedfishResourceLib.inf
 
   !include RedfishPkg/Redfish.dsc.inc

--- a/RedfishPkg/RedfishResourceDxe/RedfishResourceDxe.c
+++ b/RedfishPkg/RedfishResourceDxe/RedfishResourceDxe.c
@@ -1,0 +1,355 @@
+/** @file
+  RedfishResourceDxe installs EFI_REDFISH_RESOURCE_PROTOCOL.
+
+  This driver provides a data repository for platform Redfish resource.
+  Platform porting code calls SetResource() to publish data; Redfish feature
+  drivers call GetResource() to retrieve it.
+
+  The protocol is type-agnostic: it stores opaque VOID* blobs keyed by
+  ResourceTypeName. The protocol takes ownership of the Data buffer passed
+  to SetResource() — caller must not free/reuse/modify it afterwards.
+  GetResource() returns a direct pointer to the internal data — caller
+  must NOT free or modify it.
+
+  Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Protocol/RedfishResourceProtocol.h>
+
+#define RESOURCE_MAX_ENTRIES  32
+
+typedef struct {
+  CHAR8   *TypeName;
+  CHAR8   *MajorVersion;
+  CHAR8   *MinorVersion;
+  CHAR8   *ErrataVersion;
+  UINTN   DataSize;
+  VOID    *Data;          // Owned by this protocol (caller transferred ownership)
+} RESOURCE_DATA_ENTRY;
+
+typedef struct {
+  UINTN                          EntryCount;
+  RESOURCE_DATA_ENTRY            Entries[RESOURCE_MAX_ENTRIES];
+  EFI_REDFISH_RESOURCE_PROTOCOL  Protocol;
+} REDFISH_RESOURCE_PRIVATE;
+
+STATIC REDFISH_RESOURCE_PRIVATE  *mPrivate = NULL;
+
+/**
+  Find an existing entry by type name.
+**/
+STATIC
+RESOURCE_DATA_ENTRY *
+FindEntry (
+  IN CHAR8  *TypeName
+  )
+{
+  UINTN  Index;
+
+  for (Index = 0; Index < mPrivate->EntryCount; Index++) {
+    if (AsciiStrCmp (mPrivate->Entries[Index].TypeName, TypeName) == 0) {
+      return &mPrivate->Entries[Index];
+    }
+  }
+
+  return NULL;
+}
+
+/**
+  Helper to duplicate an ASCII string, or return NULL if input is NULL.
+**/
+STATIC
+CHAR8 *
+DupAsciiString (
+  IN CHAR8  *Str  OPTIONAL
+  )
+{
+  if (Str == NULL) {
+    return NULL;
+  }
+  return AllocateCopyPool (AsciiStrSize (Str), Str);
+}
+
+/**
+  Returns the Redfish resource types currently available.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+RedfishResourceGetSupportedResourceTypes (
+  IN  EFI_REDFISH_RESOURCE_PROTOCOL  *This,
+  OUT UINTN                          *ResourceTypeCount,
+  OUT CHAR8                          ***SupportedResources
+  )
+{
+  UINTN  Index;
+  CHAR8  **TypeArray;
+
+  if ((This == NULL) || (ResourceTypeCount == NULL) || (SupportedResources == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *ResourceTypeCount  = mPrivate->EntryCount;
+  *SupportedResources = NULL;
+
+  if (mPrivate->EntryCount == 0) {
+    return EFI_SUCCESS;
+  }
+
+  TypeArray = AllocateZeroPool (sizeof (CHAR8 *) * mPrivate->EntryCount);
+  if (TypeArray == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  for (Index = 0; Index < mPrivate->EntryCount; Index++) {
+    TypeArray[Index] = AllocateCopyPool (
+                         AsciiStrSize (mPrivate->Entries[Index].TypeName),
+                         mPrivate->Entries[Index].TypeName
+                         );
+    if (TypeArray[Index] == NULL) {
+      while (Index > 0) {
+        FreePool (TypeArray[--Index]);
+      }
+      FreePool (TypeArray);
+      return EFI_OUT_OF_RESOURCES;
+    }
+  }
+
+  *SupportedResources = TypeArray;
+  return EFI_SUCCESS;
+}
+
+/**
+  Collect the resource data for a specified Redfish resource type.
+
+  Returns a direct pointer to the internal stored data. Caller must NOT free.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+RedfishResourceGetResource (
+  IN  EFI_REDFISH_RESOURCE_PROTOCOL  *This,
+  IN  CHAR8                          *ResourceTypeName,
+  OUT CHAR8                          **MajorVersion      OPTIONAL,
+  OUT CHAR8                          **MinorVersion      OPTIONAL,
+  OUT CHAR8                          **ErrataVersion     OPTIONAL,
+  OUT UINTN                          *DataSize,
+  OUT VOID                           **Data
+  )
+{
+  RESOURCE_DATA_ENTRY  *Entry;
+
+  if ((This == NULL) || (ResourceTypeName == NULL) || (DataSize == NULL) || (Data == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Entry = FindEntry (ResourceTypeName);
+  if (Entry == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  if ((Entry->Data == NULL) || (Entry->DataSize == 0)) {
+    return EFI_NOT_FOUND;
+  }
+
+  //
+  // Return direct pointer to internal data — caller must NOT free
+  //
+  *DataSize = Entry->DataSize;
+  *Data     = Entry->Data;
+
+  if (MajorVersion != NULL) {
+    *MajorVersion = Entry->MajorVersion;
+  }
+  if (MinorVersion != NULL) {
+    *MinorVersion = Entry->MinorVersion;
+  }
+  if (ErrataVersion != NULL) {
+    *ErrataVersion = Entry->ErrataVersion;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Sets or updates resource data for a specified Redfish resource type.
+
+  The protocol takes ownership of the Data buffer. Caller must not
+  free, reuse, or modify it after this call.
+
+  If DataSize is 0 and Data is NULL, the existing entry is removed.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+RedfishResourceSetResource (
+  IN  EFI_REDFISH_RESOURCE_PROTOCOL  *This,
+  IN  CHAR8                          *ResourceTypeName,
+  IN  CHAR8                          *MajorVersion      OPTIONAL,
+  IN  CHAR8                          *MinorVersion      OPTIONAL,
+  IN  CHAR8                          *ErrataVersion     OPTIONAL,
+  IN  UINTN                          DataSize,
+  IN  VOID                           *Data              OPTIONAL
+  )
+{
+  RESOURCE_DATA_ENTRY  *Entry;
+
+  if ((This == NULL) || (ResourceTypeName == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((DataSize > 0) && (Data == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((DataSize == 0) && (Data != NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Entry = FindEntry (ResourceTypeName);
+
+  //
+  // DataSize == 0 means remove existing data
+  //
+  if (DataSize == 0) {
+    if (Entry != NULL) {
+      //
+      // We own the data, free it
+      //
+      if (Entry->Data != NULL) {
+        FreePool (Entry->Data);
+      }
+      if (Entry->TypeName != NULL) {
+        FreePool (Entry->TypeName);
+      }
+      if (Entry->MajorVersion != NULL) {
+        FreePool (Entry->MajorVersion);
+      }
+      if (Entry->MinorVersion != NULL) {
+        FreePool (Entry->MinorVersion);
+      }
+      if (Entry->ErrataVersion != NULL) {
+        FreePool (Entry->ErrataVersion);
+      }
+
+      ZeroMem (Entry, sizeof (RESOURCE_DATA_ENTRY));
+
+      //
+      // Compact: move last entry into this slot
+      //
+      if (mPrivate->EntryCount > 1) {
+        CopyMem (Entry, &mPrivate->Entries[mPrivate->EntryCount - 1], sizeof (RESOURCE_DATA_ENTRY));
+        ZeroMem (&mPrivate->Entries[mPrivate->EntryCount - 1], sizeof (RESOURCE_DATA_ENTRY));
+      }
+      mPrivate->EntryCount--;
+    }
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Update existing entry (free -> override)
+  //
+  if (Entry != NULL) {
+    if (Entry->Data != NULL) {
+      FreePool (Entry->Data);
+    }
+    if (Entry->MajorVersion != NULL) {
+      FreePool (Entry->MajorVersion);
+    }
+    if (Entry->MinorVersion != NULL) {
+      FreePool (Entry->MinorVersion);
+    }
+    if (Entry->ErrataVersion != NULL) {
+      FreePool (Entry->ErrataVersion);
+    }
+
+    Entry->Data          = Data;
+    Entry->DataSize      = DataSize;
+    Entry->MajorVersion  = DupAsciiString (MajorVersion);
+    Entry->MinorVersion  = DupAsciiString (MinorVersion);
+    Entry->ErrataVersion = DupAsciiString (ErrataVersion);
+
+    DEBUG ((DEBUG_INFO, "%a: Updated resource for %a (%u bytes)\n",
+            __func__, ResourceTypeName, DataSize));
+    return EFI_SUCCESS;
+  }
+
+  //
+  // New entry
+  //
+  if (mPrivate->EntryCount >= RESOURCE_MAX_ENTRIES) {
+    DEBUG ((DEBUG_ERROR, "%a: Resource repository full (%d entries)\n",
+            __func__, RESOURCE_MAX_ENTRIES));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Entry = &mPrivate->Entries[mPrivate->EntryCount];
+  Entry->TypeName = AllocateCopyPool (AsciiStrSize (ResourceTypeName), ResourceTypeName);
+  if (Entry->TypeName == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Entry->Data          = Data;
+  Entry->DataSize      = DataSize;
+  Entry->MajorVersion  = DupAsciiString (MajorVersion);
+  Entry->MinorVersion  = DupAsciiString (MinorVersion);
+  Entry->ErrataVersion = DupAsciiString (ErrataVersion);
+  mPrivate->EntryCount++;
+
+  DEBUG ((DEBUG_INFO, "%a: Added resource for %a (%u bytes), total entries: %u\n",
+          __func__, ResourceTypeName, DataSize, mPrivate->EntryCount));
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Entry point.
+
+  @param[in]  ImageHandle  Image handle.
+  @param[in]  SystemTable  Pointer to EFI System Table.
+
+  @retval EFI_SUCCESS      Protocol installed successfully.
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceDxeEntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  mPrivate = AllocateZeroPool (sizeof (REDFISH_RESOURCE_PRIVATE));
+  if (mPrivate == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  mPrivate->EntryCount = 0;
+  mPrivate->Protocol.GetSupportedResourceTypes = RedfishResourceGetSupportedResourceTypes;
+  mPrivate->Protocol.GetResource               = RedfishResourceGetResource;
+  mPrivate->Protocol.SetResource               = RedfishResourceSetResource;
+
+  Status = gBS->InstallMultipleProtocolInterfaces (
+                  &ImageHandle,
+                  &gEfiRedfishResourceProtocolGuid,
+                  &mPrivate->Protocol,
+                  NULL
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to install protocol: %r\n", __func__, Status));
+    FreePool (mPrivate);
+    mPrivate = NULL;
+    return Status;
+  }
+
+  DEBUG ((DEBUG_INFO, "%a: EFI_REDFISH_RESOURCE_PROTOCOL installed\n", __func__));
+  return EFI_SUCCESS;
+}

--- a/RedfishPkg/RedfishResourceDxe/RedfishResourceDxe.inf
+++ b/RedfishPkg/RedfishResourceDxe/RedfishResourceDxe.inf
@@ -1,0 +1,41 @@
+## @file
+#  RedfishResourceDxe installs EFI_REDFISH_RESOURCE_PROTOCOL.
+#
+#  This driver provides a data repository for platform Redfish resource.
+#  Platform porting code calls SetResource() to publish data; Redfish feature
+#  drivers call GetResource() to retrieve it.
+#
+#  Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = RedfishResourceDxe
+  FILE_GUID                      = 7A3C2E01-0816-4B8E-A1C9-3F7D5E8B6C02
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = RedfishResourceDxeEntryPoint
+
+[Sources]
+  RedfishResourceDxe.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  RedfishPkg/RedfishPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  MemoryAllocationLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+
+[Protocols]
+  gEfiRedfishResourceProtocolGuid    ## PRODUCES
+
+[Depex]
+  TRUE


### PR DESCRIPTION
Add EFI_REDFISH_RESOURCE_PROTOCOL as a type-agnostic data repository for platform hardware resource data. Platform porting code publishes data via SetResource(); Redfish feature drivers consume it via RedfishResourceLib (GetCount/GetEntry).

New files:
- Include/Protocol/RedfishResourceProtocol.h
- Include/Library/RedfishResourceLib.h
- RedfishResourceDxe/RedfishResourceDxe.c/.inf
- Library/RedfishResourceLib/RedfishResourceLib.c/.inf

Updated:
- RedfishPkg.dec (GUID + LibraryClass)
- RedfishLibs.dsc.inc, RedfishComponents.dsc.inc, Redfish.fdf.inc