### PR TITLE
Fix `.mergify.yml` validation errors

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -36,7 +36,6 @@ pull_request_rules:
       - status-success=Windows VS2019 PR
     actions:
       merge:
-        strict: true
         method: rebase
 
   - name: Automatically close a PR when all required checks pass and 'push' label is not present


### PR DESCRIPTION
## AI-generated fix — review carefully before merging

Mergify detected that your `.mergify.yml` was failing schema validation and produced this fix on attempt 3.

**Please review the diff carefully.** The AI may have made changes beyond the strict minimum needed to fix the validation error, and it does not have the full context of your project.

### Original validation error

```
Extra inputs are not permitted @ root → pull_request_rules → item 0 → actions → merge → strict
```

---

*Generated by Mergify's AI-assisted configuration fix.*
