### PR TITLE
SecurityPkg/DxeImageVerificationLib: Continue on dbx-forbidden signature

### DIFF
--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -2032,10 +2032,14 @@ DxeImageVerificationHandler (
 
     //
     // Check the digital signature against the revoked certificate in forbidden database (dbx).
+    // Per UEFI Spec Section, a signature found in dbx only disqualifies that
+    // signature; the image may still pass if another signature is in db and not in dbx.
+    // Therefore skip this signature and continue evaluating the remaining ones rather than
+    // failing the whole image here.
     //
     if (IsForbiddenByDbx (AuthData, AuthDataSize)) {
       Action = EFI_IMAGE_EXECUTION_AUTH_SIG_FAILED;
-      break;
+      continue;
     }
 
     //


### PR DESCRIPTION
Per UEFI Spec Section 32.5.3.3 Step C, a signed image passes validation if

one of its signatures is in db and not in dbx. A signature whose signer

certificate is found in dbx must only disqualify that signature, not the

entire image. The loop previously executed 'break' on the first

dbx-forbidden signature, wrongly denying multi-signed images that carry a

later signature valid in db and not revoked. Change 'break' to 'continue'

so remaining signatures are still evaluated.