### PR TITLE
SecurityPkg/CryptoIndicatorTableDxe: Fix ACPI table pointer type mism…

### DIFF
--- a/SecurityPkg/CryptoIndicatorTableDxe/CryptoIndicatorTableDxe.c
+++ b/SecurityPkg/CryptoIndicatorTableDxe/CryptoIndicatorTableDxe.c
@@ -434,7 +434,7 @@ CryptoIndicatorTableDxeEntryPoint (
         //
         // Locate the ACPI copy so ConfigurationTable points to the same memory.
         //
-        AcpiCopy = EfiLocateFirstAcpiTable (EFI_CRYPTO_INDICATOR_TABLE_SIGNATURE);
+        AcpiCopy = (EFI_ACPI_DESCRIPTION_HEADER *)EfiLocateFirstAcpiTable (EFI_CRYPTO_INDICATOR_TABLE_SIGNATURE);
         if (AcpiCopy != NULL) {
           ConfigTablePtr = (VOID *)AcpiCopy;
           FreePool (Table);


### PR DESCRIPTION
…atch

EfiLocateFirstAcpiTable() returns EFI_ACPI_COMMON_HEADER *, but the result

was assigned directly to an EFI_ACPI_DESCRIPTION_HEADER * variable. With

VS2022 /WX this raises warning C4133 (incompatible types), treated as an

error, breaking the build. Add an explicit cast to the destination type,

matching the convention used by all other EfiLocateFirstAcpiTable callers.