### PR TITLE
SecurityPkg/Pkcs7VerifyDxe: Deprecate X509 cert in dbx

### DIFF
--- a/SecurityPkg/Pkcs7Verify/Pkcs7VerifyDxe/GoogleTest/Pkcs7VerifyDxeGoogleTest.cpp
+++ b/SecurityPkg/Pkcs7Verify/Pkcs7VerifyDxe/GoogleTest/Pkcs7VerifyDxeGoogleTest.cpp
@@ -929,41 +929,6 @@ BuildCertHashList (
   return SigList;
 }
 
-//
-// Build a full-certificate signature list (EFI_CERT_X509_GUID), holding one
-// DER X.509 certificate. Layout: [SignatureOwner (EFI_GUID)] [certificate].
-//
-static EFI_SIGNATURE_LIST *
-BuildX509CertList (
-  IN  CONST UINT8  *Cert,
-  IN  UINTN        CertLen
-  )
-{
-  UINT32              SigSize;
-  UINTN               TotalSize;
-  EFI_SIGNATURE_LIST  *SigList;
-  UINT8               *Entry;
-
-  SigSize   = (UINT32)(sizeof (EFI_GUID) + CertLen);
-  TotalSize = sizeof (EFI_SIGNATURE_LIST) + SigSize;
-
-  SigList = (EFI_SIGNATURE_LIST *)AllocateZeroPool (TotalSize);
-  if (SigList == NULL) {
-    return NULL;
-  }
-
-  CopyGuid (&SigList->SignatureType, &gEfiCertX509Guid);
-  SigList->SignatureListSize   = (UINT32)TotalSize;
-  SigList->SignatureHeaderSize = 0;
-  SigList->SignatureSize       = SigSize;
-
-  Entry = (UINT8 *)SigList + sizeof (EFI_SIGNATURE_LIST);
-  CopyGuid ((EFI_GUID *)Entry, &mTestOwner);
-  CopyMem (Entry + sizeof (EFI_GUID), Cert, CertLen);
-
-  return SigList;
-}
-
 //////////////////////////////////////////////////////////////////////////////
 // Test fixture - computes the TBSCertificate hashes and content hashes once.
 //////////////////////////////////////////////////////////////////////////////
@@ -1634,14 +1599,13 @@ TEST_F (Pkcs7VerifyRevokeTest, NotRevokedByUnrelatedCertHash) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// Certificate chain (root in db, intermediate/root in dbx => image rejected)
+// Certificate chain (root in db, chain certificate in dbx => image rejected)
 //
 // mP7SignedChain embeds a 2-cert chain: a leaf (signer) issued by the root CA
-// (mTestCert). Note Pkcs7GetSigners() returns only the signer (leaf), so the
-// certificate-HASH revocation path inspects the leaf. A non-signer chain
-// certificate (the root/intermediate) is matched instead by the
-// full-certificate revocation path, where P7CheckRevocation verifies the
-// signature against the revoked certificate (the signature chains to it).
+// (mTestCert). A non-signer chain certificate (the root) is revoked by its TBS
+// hash via IsSignerCertChainRevokedByHash(), which walks the full chain
+// returned by Pkcs7GetCertificatesList(). Raw full-certificate dbx entries are
+// deprecated (TianoCore BZ #12527) and are ignored.
 ///////////////////////////////////////////////////////////////////////////////
 
 //
@@ -1704,35 +1668,11 @@ TEST_F (Pkcs7VerifyRevokeTest, Chain_LeafCertHashRevokedByDbx) {
 }
 
 //
-// Root/intermediate certificate present in dbx as a full EFI_CERT_X509 entry
-// revokes the signature: P7CheckRevocation verifies the chain against the
-// revoked root. This is the "intermediate/root in dbx => rejected" case.
-//
-TEST_F (Pkcs7VerifyRevokeTest, Chain_RootCertRevokedByDbx) {
-  ASSERT_TRUE (mSetUpDone);
-
-  EFI_SIGNATURE_LIST  *List = BuildX509CertList (mTestCert, sizeof (mTestCert));
-  ASSERT_NE (List, (EFI_SIGNATURE_LIST *)NULL);
-  EFI_SIGNATURE_LIST  *Dbx[] = { List, NULL };
-
-  EFI_STATUS  Status = P7CheckRevocation (
-                         (UINT8 *)mP7SignedChain,
-                         sizeof (mP7SignedChain),
-                         (UINT8 *)mTestContent,
-                         sizeof (mTestContent),
-                         Dbx
-                         );
-
-  EXPECT_EQ (Status, EFI_SUCCESS);
-
-  FreePool (List);
-}
-
-//
 // The scenario of interest: the leaf signer would be allowed by db, but the
-// root certificate is revoked in dbx. Because the EFI_PKCS7_VERIFY_PROTOCOL
-// runs the revocation check (P7CheckRevocation) before the trust check
-// (P7CheckTrust), the revocation wins and the image is rejected.
+// root certificate is revoked in dbx by its TBS hash. Because the
+// EFI_PKCS7_VERIFY_PROTOCOL runs the revocation check (P7CheckRevocation)
+// before the trust check (P7CheckTrust), the revocation wins and the image is
+// rejected.
 //
 TEST_F (Pkcs7VerifyRevokeTest, Chain_RootInDbxOverridesDbAllow) {
   ASSERT_TRUE (mSetUpDone);
@@ -1749,9 +1689,13 @@ TEST_F (Pkcs7VerifyRevokeTest, Chain_RootInDbxOverridesDbAllow) {
   EFI_SIGNATURE_LIST  *Db[] = { DbList, NULL };
 
   //
-  // dbx: revoke the root certificate (full EFI_CERT_X509 entry).
+  // dbx: revoke the root certificate by its TBS hash (EFI_CERT_X509_SHA256).
   //
-  EFI_SIGNATURE_LIST  *DbxList = BuildX509CertList (mTestCert, sizeof (mTestCert));
+  UINT8               *DbxHashes[] = { mTbsHash256 };
+  EFI_SIGNATURE_LIST  *DbxList     = BuildCertHashList (
+                                       &gEfiCertX509Sha256Guid, FALSE,
+                                       DbxHashes, SHA256_DIGEST_SIZE, 1
+                                       );
   ASSERT_NE (DbxList, (EFI_SIGNATURE_LIST *)NULL);
   EFI_SIGNATURE_LIST  *Dbx[] = { DbxList, NULL };
 

--- a/SecurityPkg/Pkcs7Verify/Pkcs7VerifyDxe/Pkcs7VerifyDxe.c
+++ b/SecurityPkg/Pkcs7Verify/Pkcs7VerifyDxe/Pkcs7VerifyDxe.c
@@ -580,17 +580,9 @@ P7CheckRevocationByHash (
   IN EFI_SIGNATURE_LIST  **RevokedDb
   )
 {
-  EFI_STATUS          Status;
-  EFI_SIGNATURE_LIST  *SigList;
-  EFI_SIGNATURE_DATA  *SigData;
-  UINT8               *RevokedCert;
-  UINTN               RevokedCertSize;
-  UINTN               Index;
+  EFI_STATUS  Status;
 
-  Status          = EFI_SECURITY_VIOLATION;
-  SigData         = NULL;
-  RevokedCert     = NULL;
-  RevokedCertSize = 0;
+  Status = EFI_SECURITY_VIOLATION;
 
   //
   // The signedData is revoked if the hash of content existed in RevokedDb
@@ -601,55 +593,13 @@ P7CheckRevocationByHash (
   }
 
   //
-  // Check if the signer's certificate can be found in Revoked database
+  // Raw X.509 certificate (EFI_CERT_X509_GUID / EFI_CERT_V2_X509_GUID) entries
+  // are deprecated in the forbidden database (dbx) - see TianoCore BZ #12527.
+  // Supporting full certificates in dbx is a burden (e.g. unsupported
+  // algorithms within a multi-cert entry) and the certificates themselves can
+  // be very large (e.g. PQC). Revocation now relies solely on the To-Be-Signed
+  // certificate hash. Any raw X.509 entry in dbx is ignored.
   //
-  for (Index = 0; ; Index++) {
-    SigList = (EFI_SIGNATURE_LIST *)(RevokedDb[Index]);
-
-    //
-    // The list is terminated by a NULL pointer.
-    //
-    if (SigList == NULL) {
-      break;
-    }
-
-    //
-    // Ignore any non-X509-format entry in the list.
-    //
-    if (!CompareGuid (&SigList->SignatureType, &gEfiCertX509Guid) &&
-        !CompareGuid (&SigList->SignatureType, &gEfiCertV2X509Guid)) {
-      continue;
-    }
-
-    SigData = (EFI_SIGNATURE_DATA *)((UINT8 *)SigList + sizeof (EFI_SIGNATURE_LIST) +
-                                     SigList->SignatureHeaderSize);
-
-    if (CompareGuid (&SigList->SignatureType, &gEfiCertV2X509Guid)) {
-      RevokedCert     = (UINT8 *)SigData;
-      RevokedCertSize = SigList->SignatureSize;
-    } else {
-      RevokedCert     = SigData->SignatureData;
-      RevokedCertSize = SigList->SignatureSize - sizeof (EFI_GUID);
-    }
-
-    //
-    // Verifying the PKCS#7 SignedData with the revoked certificate in RevokedDb
-    //
-    if (AuthenticodeVerify (SignedData, SignedDataSize, RevokedCert, RevokedCertSize, InHash, InHashSize)) {
-      //
-      // The signedData was verified by one entry in Revoked Database
-      //
-      Status = EFI_SUCCESS;
-      break;
-    }
-  }
-
-  if (!EFI_ERROR (Status)) {
-    //
-    // The signedData was revoked, since it was hit by RevokedDb
-    //
-    goto _Exit;
-  }
 
   //
   // Check the X.509 Certificate Hash in the revoked database against every
@@ -703,17 +653,9 @@ P7CheckRevocation (
   IN EFI_SIGNATURE_LIST  **RevokedDb
   )
 {
-  EFI_STATUS          Status;
-  EFI_SIGNATURE_LIST  *SigList;
-  EFI_SIGNATURE_DATA  *SigData;
-  UINT8               *RevokedCert;
-  UINTN               RevokedCertSize;
-  UINTN               Index;
+  EFI_STATUS  Status;
 
-  Status          = EFI_UNSUPPORTED;
-  SigData         = NULL;
-  RevokedCert     = NULL;
-  RevokedCertSize = 0;
+  Status = EFI_UNSUPPORTED;
 
   //
   // The signedData is revoked if the hash of content existed in RevokedDb
@@ -724,55 +666,13 @@ P7CheckRevocation (
   }
 
   //
-  // Check if the signer's certificate can be found in Revoked database
+  // Raw X.509 certificate (EFI_CERT_X509_GUID / EFI_CERT_V2_X509_GUID) entries
+  // are deprecated in the forbidden database (dbx) - see TianoCore BZ #12527.
+  // Supporting full certificates in dbx is a burden (e.g. unsupported
+  // algorithms within a multi-cert entry) and the certificates themselves can
+  // be very large (e.g. PQC). Revocation now relies solely on the To-Be-Signed
+  // certificate hash. Any raw X.509 entry in dbx is ignored.
   //
-  for (Index = 0; ; Index++) {
-    SigList = (EFI_SIGNATURE_LIST *)(RevokedDb[Index]);
-
-    //
-    // The list is terminated by a NULL pointer.
-    //
-    if (SigList == NULL) {
-      break;
-    }
-
-    //
-    // Ignore any non-X509-format entry in the list.
-    //
-    if (!CompareGuid (&SigList->SignatureType, &gEfiCertX509Guid) &&
-        !CompareGuid (&SigList->SignatureType, &gEfiCertV2X509Guid)) {
-      continue;
-    }
-
-    SigData = (EFI_SIGNATURE_DATA *)((UINT8 *)SigList + sizeof (EFI_SIGNATURE_LIST) +
-                                     SigList->SignatureHeaderSize);
-
-    if (CompareGuid (&SigList->SignatureType, &gEfiCertV2X509Guid)) {
-      RevokedCert     = (UINT8 *)SigData;
-      RevokedCertSize = SigList->SignatureSize;
-    } else {
-      RevokedCert     = SigData->SignatureData;
-      RevokedCertSize = SigList->SignatureSize - sizeof (EFI_GUID);
-    }
-
-    //
-    // Verifying the PKCS#7 SignedData with the revoked certificate in RevokedDb
-    //
-    if (Pkcs7Verify (SignedData, SignedDataSize, RevokedCert, RevokedCertSize, InData, InDataSize)) {
-      //
-      // The signedData was verified by one entry in Revoked Database
-      //
-      Status = EFI_SUCCESS;
-      break;
-    }
-  }
-
-  if (!EFI_ERROR (Status)) {
-    //
-    // The signedData was revoked, since it was hit by RevokedDb
-    //
-    goto _Exit;
-  }
 
   //
   // Check the X.509 Certificate Hash in the revoked database against every


### PR DESCRIPTION
Ref: https://github.com/tianocore/edk2/issues/12527

Remove raw X.509 certificate (EFI_CERT_X509_GUID / EFI_CERT_V2_X509_GUID) revocation from the forbidden database (dbx) path in P7CheckRevocation() and P7CheckRevocationByHash(). Per TianoCore BZ #12527, supporting full certificates in dbx is a burden (a multi-cert entry may include an unsupported algorithm) and the certificates can be very large (e.g. PQC). Revocation now relies solely on the To-Be-Signed certificate hash (EFI_CERT_X509_SHAxxx), which the chain walk in
IsSignerCertChainRevokedByHash() already enforces against every certificate in the signing chain. This mirrors the DxeImageVerificationLib dbx behavior, which is likewise hash-only.

Any raw X.509 entry in dbx is now ignored. The db (allow) path is unchanged and still accepts full X.509 certificates.

Update the host tests accordingly: Chain_RootInDbxOverridesDbAllow now revokes the root by its TBS hash (EFI_CERT_X509_SHA256) instead of a full certificate. The full-certificate revocation test and its BuildX509CertList helper are removed, since revocation of any chain certificate (including the root) is already covered by hash-based tests (Chain3_RootCertHashRevokedByDbx and the override test). All 33 cases pass under the VS2022 host build with AddressSanitizer.