### PR TITLE
SecurityPkg/Pkcs7VerifyDxe: Evaluate every entry of an EFI_CERT_X509 db list

### DIFF
--- a/SecurityPkg/Pkcs7Verify/Pkcs7VerifyDxe/GoogleTest/Pkcs7VerifyDxeGoogleTest.cpp
+++ b/SecurityPkg/Pkcs7Verify/Pkcs7VerifyDxe/GoogleTest/Pkcs7VerifyDxeGoogleTest.cpp
@@ -5184,6 +5184,56 @@ TEST (MlDsaMultiSignerTest, ValidCoSignerSignature_Accepted) {
   FreePool (SigData);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// P7CheckTrust - a single EFI_CERT_X509 AllowedDb list may carry more than one
+// certificate entry; every entry must be evaluated, not just the first.
+//
+// Build a 2-entry EFI_CERT_X509 list whose first entry is a byte-corrupted copy
+// of the signing root (does not verify) and whose second entry is the real root
+// mTestCert (verifies mP7SignedChain). If only the first entry were checked the
+// image would be wrongly rejected; evaluating all entries accepts it.
+///////////////////////////////////////////////////////////////////////////////
+TEST (P7CheckTrustMultiEntryX509Test, SecondEntryVerifies_Accepted) {
+  UINTN  EntrySize = sizeof (EFI_GUID) + sizeof (mTestCert);
+  UINTN  ListSize  = sizeof (EFI_SIGNATURE_LIST) + EntrySize * 2;
+
+  EFI_SIGNATURE_LIST  *List = (EFI_SIGNATURE_LIST *)AllocateZeroPool (ListSize);
+  ASSERT_NE (List, (EFI_SIGNATURE_LIST *)NULL);
+  CopyGuid (&List->SignatureType, &gEfiCertX509Guid);
+  List->SignatureListSize   = (UINT32)ListSize;
+  List->SignatureHeaderSize = 0;
+  List->SignatureSize       = (UINT32)EntrySize;
+
+  UINT8  *Entry0 = (UINT8 *)List + sizeof (EFI_SIGNATURE_LIST);
+  UINT8  *Entry1 = Entry0 + EntrySize;
+
+  //
+  // Entry 0: corrupted copy of mTestCert (SignatureData starts after the owner
+  // GUID). Flipping a byte makes Pkcs7Verify() fail to anchor on it.
+  //
+  CopyMem (Entry0 + sizeof (EFI_GUID), mTestCert, sizeof (mTestCert));
+  (Entry0 + sizeof (EFI_GUID))[sizeof (mTestCert) / 2] ^= 0xFF;
+
+  //
+  // Entry 1: the real signing root.
+  //
+  CopyMem (Entry1 + sizeof (EFI_GUID), mTestCert, sizeof (mTestCert));
+
+  EFI_SIGNATURE_LIST  *Db[] = { List, NULL };
+
+  EFI_STATUS  Status = P7CheckTrust (
+                         (UINT8 *)mP7SignedChain,
+                         sizeof (mP7SignedChain),
+                         (UINT8 *)mTestContent,
+                         sizeof (mTestContent),
+                         Db,
+                         NULL
+                         );
+
+  EXPECT_EQ (Status, EFI_SUCCESS);
+
+  FreePool (List);
+}
 
 int
 main (

--- a/SecurityPkg/Pkcs7Verify/Pkcs7VerifyDxe/Pkcs7VerifyDxe.c
+++ b/SecurityPkg/Pkcs7Verify/Pkcs7VerifyDxe/Pkcs7VerifyDxe.c
@@ -767,6 +767,7 @@ P7CheckTrustByHash (
   UINT8               *Cert;
   UINTN               CertSize;
   UINTN               CertIndex;
+  UINTN               CertCount;
 
   Status        = EFI_SECURITY_VIOLATION;
   SigData       = NULL;
@@ -795,34 +796,45 @@ P7CheckTrustByHash (
 
     if (CompareGuid (&SigList->SignatureType, &gEfiCertX509Guid) ||
         CompareGuid (&SigList->SignatureType, &gEfiCertV2X509Guid)) {
-      SigData = (EFI_SIGNATURE_DATA *)((UINT8 *)SigList + sizeof (EFI_SIGNATURE_LIST) +
-                                       SigList->SignatureHeaderSize);
-
-      if (CompareGuid (&SigList->SignatureType, &gEfiCertV2X509Guid)) {
-        TrustCert     = (UINT8 *)SigData;
-        TrustCertSize = SigList->SignatureSize;
-      } else {
-        TrustCert     = SigData->SignatureData;
-        TrustCertSize = SigList->SignatureSize - sizeof (EFI_GUID);
-      }
-
       //
-      // Verifying the PKCS#7 SignedData with the trusted certificate from AllowedDb
+      // A single EFI_CERT_X509 / EFI_CERT_V2_X509 list may hold more than one
+      // certificate entry, each a candidate trust anchor. Evaluate every entry,
+      // not just the first.
       //
-      if (AuthenticodeVerify (SignedData, SignedDataSize, TrustCert, TrustCertSize, InHash, InHashSize)) {
+      SigData    = (EFI_SIGNATURE_DATA *)((UINT8 *)SigList + sizeof (EFI_SIGNATURE_LIST) +
+                                          SigList->SignatureHeaderSize);
+      CertCount  = (SigList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) -
+                    SigList->SignatureHeaderSize) / SigList->SignatureSize;
+
+      for (CertIndex = 0; CertIndex < CertCount; CertIndex++) {
+        if (CompareGuid (&SigList->SignatureType, &gEfiCertV2X509Guid)) {
+          TrustCert     = (UINT8 *)SigData;
+          TrustCertSize = SigList->SignatureSize;
+        } else {
+          TrustCert     = SigData->SignatureData;
+          TrustCertSize = SigList->SignatureSize - sizeof (EFI_GUID);
+        }
+
         //
-        // The SignedData verified up to this db certificate (the trust anchor).
-        // Per UEFI Spec 32.5.3.3, the image is trusted only if neither the
-        // trust anchor nor any certificate below it (toward the leaf) is revoked
-        // in dbx; certificates above the anchor are ignored.
+        // Verifying the PKCS#7 SignedData with the trusted certificate from AllowedDb
         //
-        if (IsSignerCertChainRevokedByHash (SignedData, SignedDataSize, RevokedDb, TrustCert, TrustCertSize)) {
-          Status = EFI_SECURITY_VIOLATION;
+        if (AuthenticodeVerify (SignedData, SignedDataSize, TrustCert, TrustCertSize, InHash, InHashSize)) {
+          //
+          // The SignedData verified up to this db certificate (the trust anchor).
+          // Per UEFI Spec 32.5.3.3, the image is trusted only if neither the
+          // trust anchor nor any certificate below it (toward the leaf) is revoked
+          // in dbx; certificates above the anchor are ignored.
+          //
+          if (IsSignerCertChainRevokedByHash (SignedData, SignedDataSize, RevokedDb, TrustCert, TrustCertSize)) {
+            Status = EFI_SECURITY_VIOLATION;
+            goto _Exit;
+          }
+
+          Status = EFI_SUCCESS;
           goto _Exit;
         }
 
-        Status = EFI_SUCCESS;
-        goto _Exit;
+        SigData = (EFI_SIGNATURE_DATA *)((UINT8 *)SigData + SigList->SignatureSize);
       }
     } else if (CompareGuid (&SigList->SignatureType, &gEfiCertX509Sha256Guid) ||
                CompareGuid (&SigList->SignatureType, &gEfiCertX509Sha384Guid) ||
@@ -957,6 +969,7 @@ P7CheckTrust (
   UINT8               *Cert;
   UINTN               CertSize;
   UINTN               CertIndex;
+  UINTN               CertCount;
 
   Status        = EFI_SECURITY_VIOLATION;
   SigData       = NULL;
@@ -985,34 +998,45 @@ P7CheckTrust (
 
     if (CompareGuid (&SigList->SignatureType, &gEfiCertX509Guid) ||
         CompareGuid (&SigList->SignatureType, &gEfiCertV2X509Guid)) {
-      SigData = (EFI_SIGNATURE_DATA *)((UINT8 *)SigList + sizeof (EFI_SIGNATURE_LIST) +
-                                       SigList->SignatureHeaderSize);
-
-      if (CompareGuid (&SigList->SignatureType, &gEfiCertV2X509Guid)) {
-        TrustCert     = (UINT8 *)SigData;
-        TrustCertSize = SigList->SignatureSize;
-      } else {
-        TrustCert     = SigData->SignatureData;
-        TrustCertSize = SigList->SignatureSize - sizeof (EFI_GUID);
-      }
-
       //
-      // Verifying the PKCS#7 SignedData with the trusted certificate from AllowedDb
+      // A single EFI_CERT_X509 / EFI_CERT_V2_X509 list may hold more than one
+      // certificate entry, each a candidate trust anchor. Evaluate every entry,
+      // not just the first.
       //
-      if (Pkcs7Verify (SignedData, SignedDataSize, TrustCert, TrustCertSize, InData, InDataSize)) {
+      SigData    = (EFI_SIGNATURE_DATA *)((UINT8 *)SigList + sizeof (EFI_SIGNATURE_LIST) +
+                                          SigList->SignatureHeaderSize);
+      CertCount  = (SigList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) -
+                    SigList->SignatureHeaderSize) / SigList->SignatureSize;
+
+      for (CertIndex = 0; CertIndex < CertCount; CertIndex++) {
+        if (CompareGuid (&SigList->SignatureType, &gEfiCertV2X509Guid)) {
+          TrustCert     = (UINT8 *)SigData;
+          TrustCertSize = SigList->SignatureSize;
+        } else {
+          TrustCert     = SigData->SignatureData;
+          TrustCertSize = SigList->SignatureSize - sizeof (EFI_GUID);
+        }
+
         //
-        // The SignedData verified up to this db certificate (the trust anchor).
-        // Per UEFI Spec 32.5.3.3, the image is trusted only if neither the
-        // trust anchor nor any certificate below it (toward the leaf) is revoked
-        // in dbx; certificates above the anchor are ignored.
+        // Verifying the PKCS#7 SignedData with the trusted certificate from AllowedDb
         //
-        if (IsSignerCertChainRevokedByHash (SignedData, SignedDataSize, RevokedDb, TrustCert, TrustCertSize)) {
-          Status = EFI_SECURITY_VIOLATION;
+        if (Pkcs7Verify (SignedData, SignedDataSize, TrustCert, TrustCertSize, InData, InDataSize)) {
+          //
+          // The SignedData verified up to this db certificate (the trust anchor).
+          // Per UEFI Spec 32.5.3.3, the image is trusted only if neither the
+          // trust anchor nor any certificate below it (toward the leaf) is revoked
+          // in dbx; certificates above the anchor are ignored.
+          //
+          if (IsSignerCertChainRevokedByHash (SignedData, SignedDataSize, RevokedDb, TrustCert, TrustCertSize)) {
+            Status = EFI_SECURITY_VIOLATION;
+            goto _Exit;
+          }
+
+          Status = EFI_SUCCESS;
           goto _Exit;
         }
 
-        Status = EFI_SUCCESS;
-        goto _Exit;
+        SigData = (EFI_SIGNATURE_DATA *)((UINT8 *)SigData + SigList->SignatureSize);
       }
     } else if (CompareGuid (&SigList->SignatureType, &gEfiCertX509Sha256Guid) ||
                CompareGuid (&SigList->SignatureType, &gEfiCertX509Sha384Guid) ||


### PR DESCRIPTION
P7CheckTrust() and P7CheckTrustByHash() handled an AllowedDb EFI_CERT_X509 / EFI_CERT_V2_X509 signature list by examining only its first certificate entry: they read the first EFI_SIGNATURE_DATA, tried to verify the signature up to it, and on failure moved on to the next signature list - silently ignoring any remaining certificate entries in the same list.

A single EFI_SIGNATURE_LIST may contain N entries of its SignatureType (N = (SignatureListSize - sizeof(EFI_SIGNATURE_LIST) - SignatureHeaderSize) / SignatureSize). For a full-certificate list each entry is a distinct candidate trust anchor. If an image's signature chained to the second or later certificate in such a list, the driver failed to find a trust anchor that is actually present in db and wrongly rejected a legitimately signed image.

Iterate every certificate entry in the list, matching the behavior already implemented by DxeImageVerificationLib's IsAllowedByDb(). The common case of one certificate per list (N = 1) is unchanged.

Add a host test (P7CheckTrustMultiEntryX509Test) with a two-entry EFI_CERT_X509 db list whose first entry is a corrupted copy of the signing root and whose second entry is the real root: it fails against the previous first-entry-only code and passes now. All Pkcs7VerifyDxe host tests pass under the VS2022 build with AddressSanitizer.

ref https://github.com/tianocore/edk2/issues/12526