### PR TITLE
SecurityPkg/Pkcs7VerifyDxe: Remove SHA-1 from CalculateDataHash

### DIFF
--- a/SecurityPkg/Pkcs7Verify/Pkcs7VerifyDxe/GoogleTest/Pkcs7VerifyDxeGoogleTest.inf
+++ b/SecurityPkg/Pkcs7Verify/Pkcs7VerifyDxe/GoogleTest/Pkcs7VerifyDxeGoogleTest.inf
@@ -40,7 +40,6 @@
 [Guids]
   gEfiCertX509Guid
   gEfiCertV2X509Guid
-  gEfiCertSha1Guid
   gEfiCertSha256Guid
   gEfiCertV2Sha256Guid
   gEfiCertSha384Guid

--- a/SecurityPkg/Pkcs7Verify/Pkcs7VerifyDxe/Pkcs7VerifyDxe.c
+++ b/SecurityPkg/Pkcs7Verify/Pkcs7VerifyDxe/Pkcs7VerifyDxe.c
@@ -46,21 +46,8 @@ CalculateDataHash (
   Status  = FALSE;
   HashCtx = NULL;
 
-  if (CompareGuid (CertGuid, &gEfiCertSha1Guid)) {
-    //
-    // SHA-1 Hash
-    //
-    CtxSize = Sha1GetContextSize ();
-    HashCtx = AllocatePool (CtxSize);
-    if (HashCtx == NULL) {
-      goto _Exit;
-    }
-
-    Status = Sha1Init (HashCtx);
-    Status = Sha1Update (HashCtx, Data, DataSize);
-    Status = Sha1Final (HashCtx, HashValue);
-  } else if (CompareGuid (CertGuid, &gEfiCertSha256Guid) ||
-             CompareGuid (CertGuid, &gEfiCertV2Sha256Guid)) {
+  if (CompareGuid (CertGuid, &gEfiCertSha256Guid) ||
+      CompareGuid (CertGuid, &gEfiCertV2Sha256Guid)) {
     //
     // SHA256 Hash
     //

--- a/SecurityPkg/Pkcs7Verify/Pkcs7VerifyDxe/Pkcs7VerifyDxe.inf
+++ b/SecurityPkg/Pkcs7Verify/Pkcs7VerifyDxe/Pkcs7VerifyDxe.inf
@@ -50,7 +50,6 @@
 [Guids]
   gEfiCertX509Guid              ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
   gEfiCertV2X509Guid            ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
-  gEfiCertSha1Guid              ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
   gEfiCertSha256Guid            ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
   gEfiCertV2Sha256Guid          ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
   gEfiCertSha384Guid            ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.


### PR DESCRIPTION
Ref https://github.com/tianocore/edk2/issues/12406

CalculateDataHash() carried a SHA-1 branch (gEfiCertSha1Guid -> Sha1*), but it was unreachable: the content-hash signature types defined by UEFI Spec 32.5.3.3 for db/dbx are EFI_CERT_SHA256/384/512 and their EFI_CERT_V2_SHA* variants, and no caller passes a SHA-1 type. The only caller, IsContentHashRevoked(), iterates the revocation database and only matches those SHA-256/384/512 content-hash lists.

Drop the SHA-1 branch and remove gEfiCertSha1Guid from the driver and host-test INF [Guids]. This keeps the driver free of SHA-1, which some BaseCryptLib configurations disable.

No functional change for the supported hash types. All Pkcs7VerifyDxe host tests pass under the VS2022 build with AddressSanitizer.